### PR TITLE
Display the error on failed processing of csv records

### DIFF
--- a/src/manual.ts
+++ b/src/manual.ts
@@ -13,9 +13,13 @@ else {
 
     // Determine convertor type and run conversion.
     createAndRunConverter(
-        process.argv[2].toLocaleLowerCase(), 
-        inputFile, 
+        process.argv[2].toLocaleLowerCase(),
+        inputFile,
         ".",
         () => { process.exit(0); },
-        () => { process.exit(99); });
+        (error) => {
+            console.log(`[e] Error details: ${error}`);
+            process.exit(99);
+        }
+    );
 }


### PR DESCRIPTION
## Added

- Add an error display in case the process fails if executed locally, such as the docker version here: https://github.com/dickwolff/Export-To-Ghostfolio/blob/51834f42dc2102f53f2a1461c5be1e6ff0ec7ef1/src/watcher.ts#L75
 
Related to this issue: https://github.com/dickwolff/Export-To-Ghostfolio/issues/35
