### PR TITLE
Pin `tsx` to version 4.9.0 due to errors in 4.9.1

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 0.12.0
+next-version: 0.12.1
 assembly-informational-format: "{NuGetVersion}"
 mode: ContinuousDeployment
 branches:

--- a/package.json
+++ b/package.json
@@ -16,21 +16,21 @@
   "devDependencies": {
     "@types/cacache": "^17.0.2",
     "@types/jest": "^29.5.11",
-    "@types/node": "^20.11.25",
+    "@types/node": "^20.12.8",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
-    "tsx": "^4.7.2",
+    "tsx": "4.9.0",
     "typescript": "^5.4.5"
   },
   "dependencies": {
     "@types/cli-progress": "^3.11.5",
-    "cacache": "^18.0.2",
+    "cacache": "^18.0.3",
     "chokidar": "^3.6.0",
     "cli-progress": "^3.12.0",
     "closest-match": "^1.3.3",
     "csv-parse": "^5.5.5",
-    "dayjs": "^1.11.10",
+    "dayjs": "^1.11.11",
     "dotenv": "^16.4.5",
     "yahoo-finance2": "^2.11.2"
   }


### PR DESCRIPTION
## Fixes

- 🐛 Pinned `tsx` to version 4.9.0 because there are erros with 4.9.1+
- 🏗️ Updates some other outdated dependencies

## Checklist

- [ ] ~~Added relevant changes to README (if applicable)~~
- [ ] ~~Added relevant test(s)~~
- [x] Updated GitVersion file

## Related issue (if applicable)

Fixes #65 #64 
