### PR TITLE
Fix Schwab converter

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 
 - [ ] Added relevant changes to README (if applicable)
 - [ ] Added relevant test(s)
-- [ ] Updated GitVersion file
+- [ ] Updated GitVersion file and corresponding version in `package.json`
 
 ## Related issue (if applicable)
 

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 0.13.1
+next-version: 0.13.2
 assembly-informational-format: "{NuGetVersion}"
 mode: ContinuousDeployment
 branches:

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 0.13.0
+next-version: 0.13.1
 assembly-informational-format: "{NuGetVersion}"
 mode: ContinuousDeployment
 branches:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,7 +14,8 @@ const config: Config.InitialOptions = {
     '/src/manual.ts',
     '/src/watcher.ts',
     '/src/converter.ts'],
-  coverageReporters: ['text', 'cobertura', 'html']
+  coverageReporters: ['text', 'cobertura', 'html'],
+  setupFiles: ["<rootDir>/src/testing/testEnvVars.js"]
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "export-to-ghostfolio",
-  "version": "1.0.0",
+  "version": "0.13.1",
   "type": "module",
   "description": "Convert multiple broker exports to Ghostfolio import",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "export-to-ghostfolio",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "type": "module",
   "description": "Convert multiple broker exports to Ghostfolio import",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
   "devDependencies": {
     "@types/cacache": "^17.0.2",
     "@types/jest": "^29.5.11",
-    "@types/node": "^20.12.8",
+    "@types/node": "^20.12.12",
     "jest": "^29.7.0",
-    "ts-jest": "^29.1.1",
+    "ts-jest": "^29.1.3",
     "ts-node": "^10.9.2",
-    "tsx": "^4.9.3",
+    "tsx": "^4.10.5",
     "typescript": "^5.4.5"
   },
   "dependencies": {
@@ -29,7 +29,7 @@
     "chokidar": "^3.6.0",
     "cli-progress": "^3.12.0",
     "closest-match": "^1.3.3",
-    "csv-parse": "^5.5.5",
+    "csv-parse": "^5.5.6",
     "dayjs": "^1.11.11",
     "dotenv": "^16.4.5",
     "yahoo-finance2": "^2.11.2"

--- a/samples/schwab-export.csv
+++ b/samples/schwab-export.csv
@@ -99,4 +99,6 @@ Date,Action,Symbol,Description,Quantity,Price,Fees & Comm,Amount
 01/03/2023,Reinvest Shares,TCPC,BLACKROCK TCP CAPITAL CO,10.0443,$13.17,,-$132.25
 "09/08/2023","Sell","SNAXX","SCHWAB VALUE ADVANTAGE MONEY ULTRA","500,135","$1.00","","$500135.00"
 "10/18/2023","Wire Sent","","WIRED FUNDS DISBURSED","","","","-$100000.00"
+"04/08/2024","MoneyLink Transfer","","Tfr BANK OF AMERICA, N, XXXX YYYYYY ZZZ","","","","-$30.00"
+"11/07/2023","Internal Transfer","","TDA TO DW&O TRANSFER","","","","$7.06"
 Transactions Total,,,,,,,"-$26,582.91"

--- a/samples/schwab-export.csv
+++ b/samples/schwab-export.csv
@@ -101,4 +101,5 @@ Date,Action,Symbol,Description,Quantity,Price,Fees & Comm,Amount
 "10/18/2023","Wire Sent","","WIRED FUNDS DISBURSED","","","","-$100000.00"
 "04/08/2024","MoneyLink Transfer","","Tfr BANK OF AMERICA, N, XXXX YYYYYY ZZZ","","","","-$30.00"
 "11/07/2023","Internal Transfer","","TDA TO DW&O TRANSFER","","","","$7.06"
+"11/07/2023","Non-Qualified Div","","TDA TRAN - NON-TAXABLE DIVIDENDS (CMF)","","","","$72.06"
 Transactions Total,,,,,,,"-$26,582.91"

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -18,12 +18,16 @@ import { Trading212Converter } from "./converters/trading212Converter";
 import { XtbConverter } from "./converters/xtbConverter";
 import { BitvavoConverter } from "./converters/bitvavoConverter";
 
+import packageInfo from "../package.json";
+
 async function createAndRunConverter(converterType: string, inputFilePath: string, outputFilePath: string, completionCallback: CallableFunction, errorCallback: CallableFunction) {
 
     // Verify if Ghostolio account ID is set (because without it there can be no valid output).
     if (!process.env.GHOSTFOLIO_ACCOUNT_ID) {
         return errorCallback(new Error("Environment variable GHOSTFOLIO_ACCOUNT_ID not set!"));
     }
+    
+    console.log(`[i] Starting Export to Ghostfolio v${packageInfo.version}`);
 
     // If DEBUG_LOGGING is enabled, set spaces to 2 else null for easier to read JSON output.
     const spaces = process.env.DEBUG_LOGGING === "true" ? 2 : null;

--- a/src/converters/abstractconverter.ts
+++ b/src/converters/abstractconverter.ts
@@ -16,7 +16,7 @@ export abstract class AbstractConverter {
             {
                 stopOnComplete: true,
                 forceRedraw: true,
-                format: "{bar} {percentage}% | ETA {eta}s | Duration: {duration}s | {value}/{total}"
+                format: "[i] {bar} {percentage}% | ETA {eta}s | Duration: {duration}s | {value}/{total}"
             },
             cliProgress.Presets.shades_classic);
     }

--- a/src/converters/schwabConverter.test.ts
+++ b/src/converters/schwabConverter.test.ts
@@ -34,7 +34,7 @@ describe("schwabConverter", () => {
       // Assert
       expect(actualExport).toBeTruthy();
       expect(actualExport.activities.length).toBeGreaterThan(0);
-      expect(actualExport.activities.length).toBe(98);
+      expect(actualExport.activities.length).toBe(99);
 
       done();
     }, () => { done.fail("Should not have an error!"); });

--- a/src/converters/schwabConverter.ts
+++ b/src/converters/schwabConverter.ts
@@ -44,6 +44,9 @@ export class SchwabConverter extends AbstractConverter {
                     else if (action.indexOf("sell") > -1) {
                         return "sell";
                     }
+                    else if (action.indexOf("non-qual") > -1) {
+                        return "cash";
+                    }
                     else if (action.indexOf("dividend") > -1 ||
                         action.indexOf("qual") > -1 ||
                         action.endsWith("reinvest")) {
@@ -101,8 +104,9 @@ export class SchwabConverter extends AbstractConverter {
                     continue;
                 }
 
-                // Custody fees or interest do not have a security, so add those immediately.
+                // Custody fees, cash or interest do not have a security, so add those immediately.
                 if (record.action.toLocaleLowerCase() === "fee" ||
+                    record.action.toLocaleLowerCase() === "cash" ||
                     record.action.toLocaleLowerCase() === "interest") {
 
                     const feeAmount = Math.abs(record.amount);

--- a/src/converters/schwabConverter.ts
+++ b/src/converters/schwabConverter.ts
@@ -192,7 +192,7 @@ export class SchwabConverter extends AbstractConverter {
         return true;
       }
 
-      const ignoredRecordTypes = ["credit", "journal"];
+      const ignoredRecordTypes = ["credit", "journal", "transfer"];
 
       let ignore = ignoredRecordTypes.some(t => record.action.toLocaleLowerCase().indexOf(t) > -1);
 

--- a/src/securityService.test.ts
+++ b/src/securityService.test.ts
@@ -41,106 +41,21 @@ describe("securityService", () => {
         expect(yahooFinance2Spy).toHaveBeenCalledTimes(1);
     });
 
-    describe("having no symbols in cache", () => {
-        describe("having ISIN", () => {
-            it("and YahooFinance returns one quote, should return symbol", async () => {
+    describe("getSecurity()", () => {
+        describe("having no symbols in cache", () => {
+            describe("having ISIN", () => {
+                it("and YahooFinance returns one quote, should return symbol", async () => {
 
-                // Arrange
-                const yahooFinanceMock = new YahooFinanceServiceMock();
-                const searchSpy = jest.spyOn(yahooFinanceMock, "search").mockResolvedValue({
-                    quotes: [
-                        {
-                            symbol: "AAPL"
-                        }
-                    ]
-                });
-                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary").mockResolvedValue({
-                    price: {
-                        regularMarketPrice: 100,
-                        currency: "USD",
-                        exchange: "NMS",
-                        symbol: "AAPL"
-                    }
-                });
-
-                // Act
-                const sut = new SecurityService(yahooFinanceMock);
-                await sut.getSecurity("US0378331005", null, null, null);
-
-                // Assert
-                expect(searchSpy).toHaveBeenCalledTimes(1);
-                expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
-            });
-
-            it("and YahooFinance returns three quotes, should return first symbol", async () => {
-
-                // Arrange
-                const yahooFinanceMock = new YahooFinanceServiceMock();
-                const searchSpy = jest.spyOn(yahooFinanceMock, "search").mockResolvedValue({
-                    quotes: [
-                        {
-                            symbol: "AAPL"
-                        },
-                        {
-                            symbol: "NVDA"
-                        },
-                        {
-                            symbol: "TSLA"
-                        }
-                    ]
-                });
-                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
-                    .mockResolvedValueOnce({
-                        price: {
-                            regularMarketPrice: 100,
-                            currency: "USD",
-                            exchange: "NMS",
-                            symbol: "AAPL"
-                        }
-                    }).mockResolvedValueOnce({
-                        price: {
-                            regularMarketPrice: 400,
-                            currency: "USD",
-                            exchange: "NMS",
-                            symbol: "NVDA"
-                        }
-                    }).mockResolvedValueOnce({
-                        price: {
-                            regularMarketPrice: 80,
-                            currency: "USD",
-                            exchange: "NMS",
-                            symbol: "TSLA"
-                        }
-                    })
-
-                // Act
-                const sut = new SecurityService(yahooFinanceMock);
-                await sut.getSecurity("US0378331005", null, null, null);
-
-                // Assert
-                expect(searchSpy).toHaveBeenCalledTimes(1);
-                expect(quoteSummarySpy).toHaveBeenCalledTimes(3);
-            });
-        });
-
-        describe("having ISIN and symbol", () => {
-            it("and Yahoo Finance returns no result for ISIN, should search by symbol", async () => {
-                // Arrange
-                const yahooFinanceMock = new YahooFinanceServiceMock();
-                const searchSpy = jest.spyOn(yahooFinanceMock, "search")
-                    .mockResolvedValueOnce({
-                        quotes: []
-                    })
-                    .mockResolvedValueOnce({
+                    // Arrange
+                    const yahooFinanceMock = new YahooFinanceServiceMock();
+                    const searchSpy = jest.spyOn(yahooFinanceMock, "search").mockResolvedValue({
                         quotes: [
                             {
                                 symbol: "AAPL"
                             }
                         ]
                     });
-
-                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
-                    .mockResolvedValueOnce({
+                    const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary").mockResolvedValue({
                         price: {
                             regularMarketPrice: 100,
                             currency: "USD",
@@ -149,18 +64,371 @@ describe("securityService", () => {
                         }
                     });
 
-                // Act
-                const sut = new SecurityService(yahooFinanceMock);
-                await sut.getSecurity("US0378331005", "AAPL", null, null);
+                    // Act
+                    const sut = new SecurityService(yahooFinanceMock);
+                    await sut.getSecurity("US0378331005", null, null, null);
 
-                // Assert
-                expect(searchSpy).toHaveBeenCalledTimes(2);
-                expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
-            })
+                    // Assert
+                    expect(searchSpy).toHaveBeenCalledTimes(1);
+                    expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
+                });
+
+                it("and YahooFinance returns three quotes, should return first symbol", async () => {
+
+                    // Arrange
+                    const yahooFinanceMock = new YahooFinanceServiceMock();
+                    const searchSpy = jest.spyOn(yahooFinanceMock, "search").mockResolvedValue({
+                        quotes: [
+                            {
+                                symbol: "AAPL"
+                            },
+                            {
+                                symbol: "NVDA"
+                            },
+                            {
+                                symbol: "TSLA"
+                            }
+                        ]
+                    });
+                    const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
+                        .mockResolvedValueOnce({
+                            price: {
+                                regularMarketPrice: 100,
+                                currency: "USD",
+                                exchange: "NMS",
+                                symbol: "AAPL"
+                            }
+                        }).mockResolvedValueOnce({
+                            price: {
+                                regularMarketPrice: 400,
+                                currency: "USD",
+                                exchange: "NMS",
+                                symbol: "NVDA"
+                            }
+                        }).mockResolvedValueOnce({
+                            price: {
+                                regularMarketPrice: 80,
+                                currency: "USD",
+                                exchange: "NMS",
+                                symbol: "TSLA"
+                            }
+                        })
+
+                    // Act
+                    const sut = new SecurityService(yahooFinanceMock);
+                    await sut.getSecurity("US0378331005", null, null, null);
+
+                    // Assert
+                    expect(searchSpy).toHaveBeenCalledTimes(1);
+                    expect(quoteSummarySpy).toHaveBeenCalledTimes(3);
+                });
+            });
+
+            describe("having ISIN and symbol", () => {
+                it("and Yahoo Finance returns no result for ISIN, should search by symbol", async () => {
+                    // Arrange
+                    const yahooFinanceMock = new YahooFinanceServiceMock();
+                    const searchSpy = jest.spyOn(yahooFinanceMock, "search")
+                        .mockResolvedValueOnce({
+                            quotes: []
+                        })
+                        .mockResolvedValueOnce({
+                            quotes: [
+                                {
+                                    symbol: "AAPL"
+                                }
+                            ]
+                        });
+
+                    const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
+                        .mockResolvedValueOnce({
+                            price: {
+                                regularMarketPrice: 100,
+                                currency: "USD",
+                                exchange: "NMS",
+                                symbol: "AAPL"
+                            }
+                        });
+
+                    // Act
+                    const sut = new SecurityService(yahooFinanceMock);
+                    await sut.getSecurity("US0378331005", "AAPL", null, null);
+
+                    // Assert
+                    expect(searchSpy).toHaveBeenCalledTimes(2);
+                    expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
+                })
+            });
+
+            describe("having only symbol", () => {
+                it("and YahooFinance returns one quote, should return symbol", async () => {
+
+                    // Arrange
+                    const yahooFinanceMock = new YahooFinanceServiceMock();
+                    const searchSpy = jest.spyOn(yahooFinanceMock, "search").mockResolvedValue({
+                        quotes: [
+                            {
+                                symbol: "AAPL"
+                            }
+                        ]
+                    });
+                    const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary").mockResolvedValue({
+                        price: {
+                            regularMarketPrice: 100,
+                            currency: "USD",
+                            exchange: "NMS",
+                            symbol: "AAPL"
+                        }
+                    });
+
+                    // Act
+                    const sut = new SecurityService(yahooFinanceMock);
+                    await sut.getSecurity(null, "AAPL", null, null);
+
+                    // Assert
+                    expect(searchSpy).toHaveBeenCalledTimes(1);
+                    expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
+                });
+            });
+
+            describe("having expected currency", () => {
+                it("and YahooFinance returns three quotes, should return symbol with matching currency", async () => {
+
+                    // Arrange
+                    const yahooFinanceMock = new YahooFinanceServiceMock();
+                    const searchSpy = jest.spyOn(yahooFinanceMock, "search").mockResolvedValue({
+                        quotes: [
+                            {
+                                symbol: "AAPL"
+                            }
+                        ]
+                    });
+                    const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
+                        .mockResolvedValueOnce({
+                            price: {
+                                regularMarketPrice: 100,
+                                currency: "EUR",
+                                exchange: "NMS",
+                                symbol: "AAPL"
+                            }
+                        }).mockResolvedValueOnce({
+                            price: {
+                                regularMarketPrice: 400,
+                                currency: "USD",
+                                exchange: "NMS",
+                                symbol: "AAPL"
+                            }
+                        }).mockResolvedValueOnce({
+                            price: {
+                                regularMarketPrice: 80,
+                                currency: "ISK",
+                                exchange: "NMS",
+                                symbol: "AAPL"
+                            }
+                        })
+
+                    // Act
+                    const sut = new SecurityService(yahooFinanceMock);
+                    const security = await sut.getSecurity(null, "AAPL", null, "USD");
+
+                    // Assert
+                    expect(searchSpy).toHaveBeenCalledTimes(2);
+                    expect(quoteSummarySpy).toHaveBeenCalledTimes(2);
+                    expect(security.currency).toBe("USD");
+                });
+
+                it("and expected currency is GBP, YahooFinance returns GBp, should return symbol with matching currency", async () => {
+
+                    // Arrange
+                    const yahooFinanceMock = new YahooFinanceServiceMock();
+                    const searchSpy = jest.spyOn(yahooFinanceMock, "search").mockResolvedValue({
+                        quotes: [
+                            {
+                                symbol: "AAPL"
+                            }
+                        ]
+                    });
+                    const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
+                        .mockResolvedValueOnce({
+                            price: {
+                                regularMarketPrice: 100,
+                                currency: "GBp",
+                                exchange: "NMS",
+                                symbol: "AAPL"
+                            }
+                        });
+
+                    // Act
+                    const sut = new SecurityService(yahooFinanceMock);
+                    const security = await sut.getSecurity(null, "AAPL", null, "GBP");
+
+                    // Assert
+                    expect(searchSpy).toHaveBeenCalledTimes(1);
+                    expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
+                    expect(security.currency).toBe("GBp");
+                });
+            });
+
+            describe("having only name", () => {
+                it("and YahooFinance returns one quote, should return symbol", async () => {
+
+                    // Arrange
+                    const yahooFinanceMock = new YahooFinanceServiceMock();
+                    const searchSpy = jest.spyOn(yahooFinanceMock, "search")
+                        .mockResolvedValue({
+                            quotes: [
+                                {
+                                    symbol: "AAPL"
+                                }
+                            ]
+                        });
+                    const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary").mockResolvedValue({
+                        price: {
+                            regularMarketPrice: 100,
+                            currency: "USD",
+                            exchange: "NMS",
+                            symbol: "AAPL"
+                        }
+                    });
+
+                    // Act
+                    const sut = new SecurityService(yahooFinanceMock);
+                    await sut.getSecurity(null, null, "Apple Inc.", null);
+
+                    // Assert
+                    expect(searchSpy).toHaveBeenCalledTimes(1);
+                    expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
+                });
+
+                it("and YahooFinance does not find a full match, so a partial match is searched and found, should return symbol", async () => {
+
+                    // Arrange
+                    const yahooFinanceMock = new YahooFinanceServiceMock();
+                    const searchSpy = jest.spyOn(yahooFinanceMock, "search")
+                        .mockResolvedValueOnce({
+                            quotes: []
+                        })
+                        .mockResolvedValueOnce({
+                            quotes: [
+                                {
+                                    symbol: "FIHBX"
+                                }
+                            ]
+                        });
+                    const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary").mockResolvedValue({
+                        price: {
+                            regularMarketPrice: 100,
+                            currency: "USD",
+                            exchange: "NDQ",
+                            symbol: "FIHBX"
+                        }
+                    });
+
+                    // Act
+                    const sut = new SecurityService(yahooFinanceMock);
+                    await sut.getSecurity(null, null, "FEDERATED HERMES INSTL HIGH YIELD BD IS", null);
+
+                    // Assert
+                    expect(searchSpy).toHaveBeenCalledTimes(2);
+                    expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
+                });
+            });
+
+            describe("having Yahoo Finance returns invalid data", () => {
+                it("with search result without a symbol, skips", async () => {
+
+                    // Arrange
+                    const yahooFinanceMock = new YahooFinanceServiceMock();
+                    const searchSpy = jest.spyOn(yahooFinanceMock, "search")
+                        .mockResolvedValue({
+                            quotes: [
+                                {
+                                    symbol: null,
+                                },
+                                {
+                                    symbol: "VWRL.AS"
+                                },
+                            ]
+                        });
+                    const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
+                        .mockResolvedValue({
+                            price: {
+                                regularMarketPrice: 100,
+                                currency: "EUR",
+                                exchange: "EMA",
+                                symbol: "VWRL"
+                            }
+                        });
+
+                    // Act
+                    const sut = new SecurityService(yahooFinanceMock);
+                    await sut.getSecurity(null, "VWRL", null, null);
+
+                    // Assert
+                    expect(searchSpy).toHaveBeenCalledTimes(1);
+                    expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
+                });
+
+                it("and throws an error for quoteSummary, skips", async () => {
+
+                    // Arrange
+                    const yahooFinanceMock = new YahooFinanceServiceMock();
+                    const searchSpy = jest.spyOn(yahooFinanceMock, "search")
+                        .mockResolvedValue({
+                            quotes: [
+                                {
+                                    symbol: "VWRL.AS"
+                                },
+                            ]
+                        });
+                    const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
+                        .mockImplementationOnce(() => { throw new Error("Unit test") })
+                        .mockResolvedValue({
+                            price: {
+                                regularMarketPrice: 100,
+                                currency: "EUR",
+                                exchange: "EMA",
+                                symbol: "VWRL"
+                            }
+                        });
+
+                    // Act
+                    const sut = new SecurityService(yahooFinanceMock);
+                    await sut.getSecurity(null, "VWRL", null, null);
+
+                    // Assert
+                    expect(searchSpy).toHaveBeenCalledTimes(2);
+                    expect(quoteSummarySpy).toHaveBeenCalledTimes(2);
+                });
+
+                it("with quoteSummary result without a price, skips", async () => {
+
+                    // Arrange
+                    const yahooFinanceMock = new YahooFinanceServiceMock();
+                    const searchSpy = jest.spyOn(yahooFinanceMock, "search")
+                        .mockResolvedValue({
+                            quotes: [
+                                {
+                                    symbol: "VWRL.AS"
+                                },
+                            ]
+                        });
+                    const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
+                        .mockResolvedValue({});
+
+                    // Act
+                    const sut = new SecurityService(yahooFinanceMock);
+                    await sut.getSecurity(null, "VWRL", null, null);
+
+                    // Assert
+                    expect(searchSpy).toHaveBeenCalledTimes(2);
+                    expect(quoteSummarySpy).toHaveBeenCalledTimes(2);
+                });
+            });
         });
 
-        describe("having only symbol", () => {
-            it("and YahooFinance returns one quote, should return symbol", async () => {
+        describe("having symbols in cache", () => {
+            it("when symbol without ISIN is searched for a second time, retrieves it from symbol cache but searches for ISIN", async () => {
 
                 // Arrange
                 const yahooFinanceMock = new YahooFinanceServiceMock();
@@ -180,18 +448,17 @@ describe("securityService", () => {
                     }
                 });
 
-                // Act
+                // Act                
                 const sut = new SecurityService(yahooFinanceMock);
+                await sut.getSecurity(null, "AAPL", null, null);
                 await sut.getSecurity(null, "AAPL", null, null);
 
                 // Assert
                 expect(searchSpy).toHaveBeenCalledTimes(1);
                 expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
             });
-        });
 
-        describe("having expected currency", () => {
-            it("and YahooFinance returns three quotes, should return symbol with matching currency", async () => {
+            it("when ISIN is searched for a second time, retrieves it from ISIN cache", async () => {
 
                 // Arrange
                 const yahooFinanceMock = new YahooFinanceServiceMock();
@@ -202,85 +469,6 @@ describe("securityService", () => {
                         }
                     ]
                 });
-                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
-                    .mockResolvedValueOnce({
-                        price: {
-                            regularMarketPrice: 100,
-                            currency: "EUR",
-                            exchange: "NMS",
-                            symbol: "AAPL"
-                        }
-                    }).mockResolvedValueOnce({
-                        price: {
-                            regularMarketPrice: 400,
-                            currency: "USD",
-                            exchange: "NMS",
-                            symbol: "AAPL"
-                        }
-                    }).mockResolvedValueOnce({
-                        price: {
-                            regularMarketPrice: 80,
-                            currency: "ISK",
-                            exchange: "NMS",
-                            symbol: "AAPL"
-                        }
-                    })
-
-                // Act
-                const sut = new SecurityService(yahooFinanceMock);
-                const security = await sut.getSecurity(null, "AAPL", null, "USD");
-
-                // Assert
-                expect(searchSpy).toHaveBeenCalledTimes(2);
-                expect(quoteSummarySpy).toHaveBeenCalledTimes(2);
-                expect(security.currency).toBe("USD");
-            });
-
-            it("and expected currency is GBP, YahooFinance returns GBp, should return symbol with matching currency", async () => {
-
-                // Arrange
-                const yahooFinanceMock = new YahooFinanceServiceMock();
-                const searchSpy = jest.spyOn(yahooFinanceMock, "search").mockResolvedValue({
-                    quotes: [
-                        {
-                            symbol: "AAPL"
-                        }
-                    ]
-                });
-                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
-                    .mockResolvedValueOnce({
-                        price: {
-                            regularMarketPrice: 100,
-                            currency: "GBp",
-                            exchange: "NMS",
-                            symbol: "AAPL"
-                        }
-                    });
-
-                // Act
-                const sut = new SecurityService(yahooFinanceMock);
-                const security = await sut.getSecurity(null, "AAPL", null, "GBP");
-
-                // Assert
-                expect(searchSpy).toHaveBeenCalledTimes(1);
-                expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
-                expect(security.currency).toBe("GBp");
-            });
-        });
-
-        describe("having only name", () => {
-            it("and YahooFinance returns one quote, should return symbol", async () => {
-
-                // Arrange
-                const yahooFinanceMock = new YahooFinanceServiceMock();
-                const searchSpy = jest.spyOn(yahooFinanceMock, "search")
-                    .mockResolvedValue({
-                        quotes: [
-                            {
-                                symbol: "AAPL"
-                            }
-                        ]
-                    });
                 const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary").mockResolvedValue({
                     price: {
                         regularMarketPrice: 100,
@@ -290,138 +478,14 @@ describe("securityService", () => {
                     }
                 });
 
-                // Act
+                // Act                
                 const sut = new SecurityService(yahooFinanceMock);
-                await sut.getSecurity(null, null, "Apple Inc.", null);
+                await sut.getSecurity("US0378331005", "AAPL", null, null);
+                await sut.getSecurity("US0378331005", "AAPL", null, null);
 
                 // Assert
                 expect(searchSpy).toHaveBeenCalledTimes(1);
                 expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
-            });
-
-            it("and YahooFinance does not find a full match, so a partial match is searched and found, should return symbol", async () => {
-
-                // Arrange
-                const yahooFinanceMock = new YahooFinanceServiceMock();
-                const searchSpy = jest.spyOn(yahooFinanceMock, "search")
-                    .mockResolvedValueOnce({
-                        quotes: []
-                    })
-                    .mockResolvedValueOnce({
-                        quotes: [
-                            {
-                                symbol: "FIHBX"
-                            }
-                        ]
-                    });
-                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary").mockResolvedValue({
-                    price: {
-                        regularMarketPrice: 100,
-                        currency: "USD",
-                        exchange: "NDQ",
-                        symbol: "FIHBX"
-                    }
-                });
-
-                // Act
-                const sut = new SecurityService(yahooFinanceMock);
-                await sut.getSecurity(null, null, "FEDERATED HERMES INSTL HIGH YIELD BD IS", null);
-
-                // Assert
-                expect(searchSpy).toHaveBeenCalledTimes(2);
-                expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
-            });
-        });
-
-        describe("having Yahoo Finance returns invalid data", () => {
-            it("with search result without a symbol, skips", async () => {
-
-                // Arrange
-                const yahooFinanceMock = new YahooFinanceServiceMock();
-                const searchSpy = jest.spyOn(yahooFinanceMock, "search")
-                    .mockResolvedValue({
-                        quotes: [
-                            {
-                                symbol: null,
-                            },
-                            {
-                                symbol: "VWRL.AS"
-                            },
-                        ]
-                    });
-                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
-                    .mockResolvedValue({
-                        price: {
-                            regularMarketPrice: 100,
-                            currency: "EUR",
-                            exchange: "EMA",
-                            symbol: "VWRL"
-                        }
-                    });
-
-                // Act
-                const sut = new SecurityService(yahooFinanceMock);
-                await sut.getSecurity(null, "VWRL", null, null);
-
-                // Assert
-                expect(searchSpy).toHaveBeenCalledTimes(1);
-                expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
-            });
-
-            it("and throws an error for quoteSummary, skips", async () => {
-
-                // Arrange
-                const yahooFinanceMock = new YahooFinanceServiceMock();
-                const searchSpy = jest.spyOn(yahooFinanceMock, "search")
-                    .mockResolvedValue({
-                        quotes: [
-                            {
-                                symbol: "VWRL.AS"
-                            },
-                        ]
-                    });
-                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
-                    .mockImplementationOnce(() => { throw new Error("Unit test") })
-                    .mockResolvedValue({
-                        price: {
-                            regularMarketPrice: 100,
-                            currency: "EUR",
-                            exchange: "EMA",
-                            symbol: "VWRL"
-                        }
-                    });
-
-                // Act
-                const sut = new SecurityService(yahooFinanceMock);
-                await sut.getSecurity(null, "VWRL", null, null);
-
-                // Assert
-                expect(searchSpy).toHaveBeenCalledTimes(1);
-                expect(quoteSummarySpy).toHaveBeenCalledTimes(2);
-            });
-
-            it("with quoteSummary result without a price, skips", async () => {
-
-                // Arrange
-                const yahooFinanceMock = new YahooFinanceServiceMock();
-                const searchSpy = jest.spyOn(yahooFinanceMock, "search")
-                    .mockResolvedValue({
-                        quotes: [
-                            {
-                                symbol: "VWRL.AS"
-                            },
-                        ]
-                    });
-                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
-                    .mockResolvedValue({});
-
-                // Act
-                const sut = new SecurityService(yahooFinanceMock);
-                await sut.getSecurity(null, "VWRL", null, null);
-
-                // Assert
-                expect(searchSpy).toHaveBeenCalledTimes(1);
-                expect(quoteSummarySpy).toHaveBeenCalledTimes(2);
             });
         });
     });

--- a/src/securityService.test.ts
+++ b/src/securityService.test.ts
@@ -1,18 +1,11 @@
-import yahooFinance from "yahoo-finance2";
-import { YahooFinanceService } from "./yahooFinanceService";
-import { YahooFinanceTestdata } from "./testing/yahooFinanceTestdataWriter";
+import * as cacache from "cacache";
 import { SecurityService } from "./securityService";
 import YahooFinanceServiceMock from "./testing/yahooFinanceServiceMock";
-
-class YahooFinanceTestdataWriterMock implements YahooFinanceTestdata {
-    addSearchResult(_, __) { }
-    addQuoteSummaryResult(_, __) { }
-}
 
 describe("securityService", () => {
 
     beforeEach(() => {
-        // jest.spyOn(console, "log").mockImplementation(jest.fn());
+        jest.spyOn(console, "log").mockImplementation(jest.fn());
     });
 
     afterEach(() => {
@@ -487,6 +480,23 @@ describe("securityService", () => {
                 expect(searchSpy).toHaveBeenCalledTimes(1);
                 expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
             });
+        });
+    });
+
+    describe("loadCache()", () => {
+
+        it("having no initial cache, does not restore", async () => {
+
+            // Arrange
+            const yahooFinanceMock = new YahooFinanceServiceMock();
+            const sut = new SecurityService(yahooFinanceMock);
+
+            // Act
+            const cache = await sut.loadCache();
+
+            // Assert
+            expect(cache[0]).toBe(0);
+            expect(cache[1]).toBe(0);
         });
     });
 });

--- a/src/securityService.test.ts
+++ b/src/securityService.test.ts
@@ -1,0 +1,303 @@
+import yahooFinance from "yahoo-finance2";
+import { YahooFinanceService } from "./yahooFinanceService";
+import { YahooFinanceTestdata } from "./testing/yahooFinanceTestdataWriter";
+import { SecurityService } from "./securityService";
+import YahooFinanceServiceMock from "./testing/yahooFinanceServiceMock";
+
+class YahooFinanceTestdataWriterMock implements YahooFinanceTestdata {
+    addSearchResult(_, __) { }
+    addQuoteSummaryResult(_, __) { }
+}
+
+describe("securityService", () => {
+
+    beforeEach(() => {
+        // jest.spyOn(console, "log").mockImplementation(jest.fn());
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should construct", () => {
+
+        // Act
+        const sut = new SecurityService(new YahooFinanceServiceMock());
+
+        // Assert
+        expect(sut).toBeTruthy();
+    });
+
+    it("setGlobalConfig() should call yahoo-finance2", () => {
+
+        // Arrange
+        const yahooFinanceMock = new YahooFinanceServiceMock();
+        const yahooFinance2Spy = jest.spyOn(yahooFinanceMock, "setGlobalConfig").mockImplementation();
+
+        // Act
+        new SecurityService(yahooFinanceMock);
+
+        // Assert
+        expect(yahooFinance2Spy).toHaveBeenCalledTimes(1);
+    });
+
+    describe("having no symbols in cache", () => {
+        describe("having ISIN", () => {
+            it("and YahooFinance returns one quote, should return symbol", async () => {
+
+                // Arrange
+                const yahooFinanceMock = new YahooFinanceServiceMock();
+                const searchSpy = jest.spyOn(yahooFinanceMock, "search").mockResolvedValue({
+                    quotes: [
+                        {
+                            symbol: "AAPL"
+                        }
+                    ]
+                });
+                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary").mockResolvedValue({
+                    price: {
+                        regularMarketPrice: 100,
+                        currency: "USD",
+                        exchange: "NMS",
+                        symbol: "AAPL"
+                    }
+                });
+
+                // Act
+                const sut = new SecurityService(yahooFinanceMock);
+                await sut.getSecurity("US0378331005", null, null, null);
+
+                // Assert
+                expect(searchSpy).toHaveBeenCalledTimes(1);
+                expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
+            });
+
+            it("and YahooFinance returns three quotes, should return first symbol", async () => {
+
+                // Arrange
+                const yahooFinanceMock = new YahooFinanceServiceMock();
+                const searchSpy = jest.spyOn(yahooFinanceMock, "search").mockResolvedValue({
+                    quotes: [
+                        {
+                            symbol: "AAPL"
+                        },
+                        {
+                            symbol: "NVDA"
+                        },
+                        {
+                            symbol: "TSLA"
+                        }
+                    ]
+                });
+                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
+                    .mockResolvedValueOnce({
+                        price: {
+                            regularMarketPrice: 100,
+                            currency: "USD",
+                            exchange: "NMS",
+                            symbol: "AAPL"
+                        }
+                    }).mockResolvedValueOnce({
+                        price: {
+                            regularMarketPrice: 400,
+                            currency: "USD",
+                            exchange: "NMS",
+                            symbol: "NVDA"
+                        }
+                    }).mockResolvedValueOnce({
+                        price: {
+                            regularMarketPrice: 80,
+                            currency: "USD",
+                            exchange: "NMS",
+                            symbol: "TSLA"
+                        }
+                    })
+
+                // Act
+                const sut = new SecurityService(yahooFinanceMock);
+                await sut.getSecurity("US0378331005", null, null, null);
+
+                // Assert
+                expect(searchSpy).toHaveBeenCalledTimes(1);
+                expect(quoteSummarySpy).toHaveBeenCalledTimes(3);
+            });
+        });
+
+        describe("having ISIN and symbol", () => {
+            it("and Yahoo Finance returns no result for ISIN, should search by symbol", async () => {
+                // Arrange
+                const yahooFinanceMock = new YahooFinanceServiceMock();
+                const searchSpy = jest.spyOn(yahooFinanceMock, "search")
+                    .mockResolvedValueOnce({
+                        quotes: []
+                    })
+                    .mockResolvedValueOnce({
+                        quotes: [
+                            {
+                                symbol: "AAPL"
+                            }
+                        ]
+                    });
+
+                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
+                    .mockResolvedValueOnce({
+                        price: {
+                            regularMarketPrice: 100,
+                            currency: "USD",
+                            exchange: "NMS",
+                            symbol: "AAPL"
+                        }
+                    });
+
+                // Act
+                const sut = new SecurityService(yahooFinanceMock);
+                await sut.getSecurity("US0378331005", "AAPL", null, null);
+
+                // Assert
+                expect(searchSpy).toHaveBeenCalledTimes(2);
+                expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
+            })
+        });
+
+        describe("having only symbol", () => {
+            it("and YahooFinance returns one quote, should return symbol", async () => {
+
+                // Arrange
+                const yahooFinanceMock = new YahooFinanceServiceMock();
+                const searchSpy = jest.spyOn(yahooFinanceMock, "search").mockResolvedValue({
+                    quotes: [
+                        {
+                            symbol: "AAPL"
+                        }
+                    ]
+                });
+                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary").mockResolvedValue({
+                    price: {
+                        regularMarketPrice: 100,
+                        currency: "USD",
+                        exchange: "NMS",
+                        symbol: "AAPL"
+                    }
+                });
+
+                // Act
+                const sut = new SecurityService(yahooFinanceMock);
+                await sut.getSecurity(null, "AAPL", null, null);
+
+                // Assert
+                expect(searchSpy).toHaveBeenCalledTimes(1);
+                expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
+            });
+        });
+
+        describe("having expected currency", () => {
+            it("and YahooFinance returns three quotes, should return symbol with matching currency", async () => {
+
+                // Arrange
+                const yahooFinanceMock = new YahooFinanceServiceMock();
+                const searchSpy = jest.spyOn(yahooFinanceMock, "search").mockResolvedValue({
+                    quotes: [
+                        {
+                            symbol: "AAPL"
+                        }
+                    ]
+                });
+                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
+                    .mockResolvedValueOnce({
+                        price: {
+                            regularMarketPrice: 100,
+                            currency: "EUR",
+                            exchange: "NMS",
+                            symbol: "AAPL"
+                        }
+                    }).mockResolvedValueOnce({
+                        price: {
+                            regularMarketPrice: 400,
+                            currency: "USD",
+                            exchange: "NMS",
+                            symbol: "AAPL"
+                        }
+                    }).mockResolvedValueOnce({
+                        price: {
+                            regularMarketPrice: 80,
+                            currency: "ISK",
+                            exchange: "NMS",
+                            symbol: "AAPL"
+                        }
+                    })
+
+                // Act
+                const sut = new SecurityService(yahooFinanceMock);
+                const security = await sut.getSecurity(null, "AAPL", null, "USD");
+
+                // Assert
+                expect(searchSpy).toHaveBeenCalledTimes(2);
+                expect(quoteSummarySpy).toHaveBeenCalledTimes(2);
+                expect(security.currency).toBe("USD");
+            });
+
+            it("and expected currency is GBP, YahooFinance returns GBp, should return symbol with matching currency", async () => {
+
+                // Arrange
+                const yahooFinanceMock = new YahooFinanceServiceMock();
+                const searchSpy = jest.spyOn(yahooFinanceMock, "search").mockResolvedValue({
+                    quotes: [
+                        {
+                            symbol: "AAPL"
+                        }
+                    ]
+                });
+                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary")
+                    .mockResolvedValueOnce({
+                        price: {
+                            regularMarketPrice: 100,
+                            currency: "GBp",
+                            exchange: "NMS",
+                            symbol: "AAPL"
+                        }
+                    });
+
+                // Act
+                const sut = new SecurityService(yahooFinanceMock);
+                const security = await sut.getSecurity(null, "AAPL", null, "GBP");
+
+                // Assert
+                expect(searchSpy).toHaveBeenCalledTimes(1);
+                expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
+                expect(security.currency).toBe("GBp");
+            });
+        });
+
+        describe("having only name", () => {
+            it("and YahooFinance returns one quote, should return symbol", async () => {
+
+                // Arrange
+                const yahooFinanceMock = new YahooFinanceServiceMock();
+                const searchSpy = jest.spyOn(yahooFinanceMock, "search")
+                    .mockResolvedValue({
+                        quotes: [
+                            {
+                                symbol: "AAPL"
+                            }
+                        ]
+                    });
+                const quoteSummarySpy = jest.spyOn(yahooFinanceMock, "quoteSummary").mockResolvedValue({
+                    price: {
+                        regularMarketPrice: 100,
+                        currency: "USD",
+                        exchange: "NMS",
+                        symbol: "AAPL"
+                    }
+                });
+
+                // Act
+                const sut = new SecurityService(yahooFinanceMock);
+                await sut.getSecurity(null, null, "Apple Inc.", null);
+
+                // Assert
+                expect(searchSpy).toHaveBeenCalledTimes(1);
+                expect(quoteSummarySpy).toHaveBeenCalledTimes(1);
+            });
+        });
+    });
+});

--- a/src/securityService.ts
+++ b/src/securityService.ts
@@ -170,6 +170,12 @@ export class SecurityService {
      * @returns The symbols that are retrieved from Yahoo Finance, if any.
      */
     private async getSymbolsByQuery(query: string, progress?: any): Promise<YahooFinanceRecord[]> {
+console.log("AAA",query)
+        // If query is empty, don't bother searching.
+        if (!query) {
+            this.logDebug("getSymbolsByQuery(): Query was empty, so no search was done with Yahoo Finance", true);
+            return [];
+        }
 
         // First get quotes for the query.
         let queryResult = await this.yahooFinance.search(query,
@@ -180,10 +186,10 @@ export class SecurityService {
             {
                 validateResult: false
             });
-
-        // Check if no match was found and a name was given (length > 10 so no ISIN).
+console.log("BBB", queryResult)
+        // Check if no match was found and a name was given (length > 12 so no ISIN).
         // In that case, try and find a partial match by removing a part of the name.
-        if (queryResult.quotes.length === 0 && query.length > 10) {
+        if (queryResult.quotes.length === 0 && query.length > 12) {
             this.logDebug(`getSymbolsByQuery(): No match found when searching by name for ${query}. Trying a partial name match with first 20 characters..`, progress, true);
             queryResult = await this.yahooFinance.search(query.substring(0, 20),
                 {
@@ -196,7 +202,7 @@ export class SecurityService {
         }
 
         const result: YahooFinanceRecord[] = [];
-
+        
         // Loop through the resulted quotes and retrieve summary data.
         for (let idx = 0; idx < queryResult.quotes.length; idx++) {
             const quote = queryResult.quotes[idx];

--- a/src/securityService.ts
+++ b/src/securityService.ts
@@ -202,7 +202,7 @@ export class SecurityService {
         }
 
         const result: YahooFinanceRecord[] = [];
-        
+
         // Loop through the resulted quotes and retrieve summary data.
         for (let idx = 0; idx < queryResult.quotes.length; idx++) {
             const quote = queryResult.quotes[idx];
@@ -307,5 +307,6 @@ export class SecurityService {
         }
     }
 
+    /* istanbul ignore next */
     private sink() { }
 }

--- a/src/securityService.ts
+++ b/src/securityService.ts
@@ -170,7 +170,7 @@ export class SecurityService {
      * @returns The symbols that are retrieved from Yahoo Finance, if any.
      */
     private async getSymbolsByQuery(query: string, progress?: any): Promise<YahooFinanceRecord[]> {
-console.log("AAA",query)
+
         // If query is empty, don't bother searching.
         if (!query) {
             this.logDebug("getSymbolsByQuery(): Query was empty, so no search was done with Yahoo Finance", true);
@@ -186,7 +186,7 @@ console.log("AAA",query)
             {
                 validateResult: false
             });
-console.log("BBB", queryResult)
+
         // Check if no match was found and a name was given (length > 12 so no ISIN).
         // In that case, try and find a partial match by removing a part of the name.
         if (queryResult.quotes.length === 0 && query.length > 12) {

--- a/src/securityService.ts
+++ b/src/securityService.ts
@@ -20,7 +20,8 @@ export class SecurityService {
      */
     constructor(private yahooFinance: YahooFinance = new YahooFinanceService()) {
 
-        // Override logging, not interested in yahooFinance2 debug logging..
+        // Override logging, not interested in yahooFinance2 debug logging..        
+        /* istanbul ignore next */
         this.yahooFinance.setGlobalConfig({
             logger: {
                 info: (...args: any[]) => this.sink(),

--- a/src/testing/testEnvVars.js
+++ b/src/testing/testEnvVars.js
@@ -1,0 +1,1 @@
+process.env.E2G_CACHE_FOLDER = "/var/tmp/e2g-cache-unittest"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "moduleResolution": "node",
         "sourceMap": true,
         "outDir": "dist",
+        "resolveJsonModule": true
     },
     "lib": ["es6"]
 }


### PR DESCRIPTION
## Added

- 🏗️ Added version to logging, to help future issue analysis
- 🕵🏼‍♂️ Added test coverage to the `SecurityService`.
 
## Fixes

- 🐛 Bumped some dependencies
- 🐛 Made `SecurityService` more robust, so it should not throw Yahoo Finance errors when symbol is empty
- 🐛 Schwab: Added `transfer` to list of ignored records
- 🐛 Schwab: Added `non-qualified div` as cash position

## Checklist

- [ ] ~Added relevant changes to README (if applicable)~
- [x] Added relevant test(s)
- [x] Updated GitVersion file

## Related issue (if applicable)

Fixes #75 
Fixes #61 