### PR TITLE
Add CSV parse errors to log

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 0.13.2
+next-version: 0.13.3
 assembly-informational-format: "{NuGetVersion}"
 mode: ContinuousDeployment
 branches:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "export-to-ghostfolio",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "type": "module",
   "description": "Convert multiple broker exports to Ghostfolio import",
   "scripts": {

--- a/src/converters/bitvavoConverter.test.ts
+++ b/src/converters/bitvavoConverter.test.ts
@@ -76,5 +76,25 @@ describe("bitvavoConverter", () => {
         done();
       });
     });
+
+    it("the header and row column count doesn't match", (done) => {
+
+      // Arrange
+      const sut = new BitvavoConverter(new SecurityService());
+
+      let tempFileContent = "";
+      tempFileContent += "Timezone,Date,Time,Type,Currency,Amount,Price (EUR),EUR received / paid,Fee currency,Fee amount,Status,Transaction ID,Address\n";
+      tempFileContent += "Europe/Amsterdam,2023-01-09,17:19:11,withdrawal,USDT,-32.156874000000003,,,USDT,5.4,Completed,1d0165bb-065f-4f0d-ba44-fb137534e010,0xaeC107aC155cA21A896888fe486de410c422424a,,"
+
+      // Act
+      sut.processFileContents(tempFileContent, () => { done.fail("Should not succeed!"); }, (err: Error) => {
+
+        // Assert
+        expect(err).toBeTruthy();
+        expect(err.message).toBe("An error ocurred while parsing! Details: Invalid Record Length: columns length is 13, got 15 on line 2");
+
+        done();
+      });
+    });
   });
 });

--- a/src/converters/bitvavoConverter.ts
+++ b/src/converters/bitvavoConverter.ts
@@ -52,11 +52,17 @@ export class BitvavoConverter extends AbstractConverter {
 
                 return columnValue;
             }
-        }, async (_, records: BitvavoRecord[]) => {
+        }, async (err, records: BitvavoRecord[]) => {
 
-            // If records is empty, parsing failed..
-            if (records === undefined || records.length === 0) {
-                return errorCallback(new Error("An error ocurred while parsing!"));
+            // Check if parsing failed..
+            if (err || records === undefined || records.length === 0) {
+                let errorMsg = "An error ocurred while parsing!";
+
+                if (err) {
+                    errorMsg += ` Details: ${err.message}`
+                }
+
+                return errorCallback(new Error(errorMsg))
             }
 
             console.log("[i] Read CSV file. Start processing..");
@@ -87,7 +93,7 @@ export class BitvavoConverter extends AbstractConverter {
                 let symbol = `${record.currency}-${record.type === "interest" ? "EUR" : record.feeCurrency}`
 
                 const date = dayjs(`${record.date} ${record.time}`, "YYYY-MM-DD HH:mm:ss");
-                
+
                 // Add record to export.
                 result.activities.push({
                     accountId: process.env.GHOSTFOLIO_ACCOUNT_ID,
@@ -110,7 +116,7 @@ export class BitvavoConverter extends AbstractConverter {
             successCallback(result);
         });
     }
-    
+
     /**
       * @inheritdoc
       */

--- a/src/converters/degiroConverter.ts
+++ b/src/converters/degiroConverter.ts
@@ -34,13 +34,18 @@ export class DeGiroConverter extends AbstractConverter {
 
         return columnValue;
       }
-    }, async (_, records: DeGiroRecord[]) => {
+    }, async (err, records: DeGiroRecord[]) => {
 
-      // If records is empty, parsing failed..
-      if (records === undefined || records.length === 0) {
-        return errorCallback(new Error("An error ocurred while parsing!"));
+      // Check if parsing failed..
+      if (err || records === undefined || records.length === 0) {
+        let errorMsg = "An error ocurred while parsing!";
+
+        if (err) {
+          errorMsg += ` Details: ${err.message}`
+        }
+
+        return errorCallback(new Error(errorMsg))
       }
-
 
       console.log("[i] Read CSV file. Start processing..");
       const result: GhostfolioExport = {

--- a/src/converters/degiroConverterV2.test.ts
+++ b/src/converters/degiroConverterV2.test.ts
@@ -77,6 +77,26 @@ describe("degiroConverterV2", () => {
       });
     });
 
+    it("the header and row column count doesn't match", (done) => {
+
+      // Arrange
+      const sut = new DeGiroConverterV2(new SecurityService());
+
+      let tempFileContent = "";
+      tempFileContent += "Datum,Tijd,Valutadatum,Product,ISIN,Omschrijving,FX,Mutatie,,Saldo,,Order Id\n";
+      tempFileContent += `15-12-2022,16:55,15-12-2022,VICI PROPERTIES INC. C,US9256521090,DEGIRO Transactiekosten en/of kosten van derden,,EUR,"-1,00",EUR,"31,98",5925d76b-eb36-46e3-b017-a61a6d03c3e7,,\n`;
+
+      // Act
+      sut.processFileContents(tempFileContent, () => { done.fail("Should not succeed!"); }, (err: Error) => {
+
+        // Assert
+        expect(err).toBeTruthy();
+        expect(err.message).toBe("An error ocurred while parsing! Details: Invalid Record Length: columns length is 12, got 14 on line 2");
+
+        done();
+      });
+    });
+
     it("Yahoo Finance throws an error", (done) => {
 
       // Arrange

--- a/src/converters/degiroConverterV2.ts
+++ b/src/converters/degiroConverterV2.ts
@@ -33,11 +33,17 @@ export class DeGiroConverterV2 extends AbstractConverter {
 
         return columnValue;
       }
-    }, async (_, records: DeGiroRecord[]) => {
+    }, async (err, records: DeGiroRecord[]) => {
 
-      // If records is empty, parsing failed..
-      if (records === undefined || records.length === 0) {
-        return errorCallback(new Error("An error ocurred while parsing!"));
+      // Check if parsing failed..
+      if (err || records === undefined || records.length === 0) {
+        let errorMsg = "An error ocurred while parsing!";
+
+        if (err) {
+          errorMsg += ` Details: ${err.message}`
+        }
+
+        return errorCallback(new Error(errorMsg))
       }
 
       console.log("[i] Read CSV file. Start processing..");

--- a/src/converters/etoroConverter.test.ts
+++ b/src/converters/etoroConverter.test.ts
@@ -77,6 +77,26 @@ describe("etoroConverter", () => {
       });
     });
 
+    it("the header and row column count doesn't match", (done) => {
+
+      // Arrange
+      const sut = new EtoroConverter(new SecurityService(new YahooFinanceServiceMock()));
+
+      let tempFileContent = "";
+      tempFileContent += "Date,Type,Details,Amount,Units,Realized Equity Change,Realized Equity,Balance,Position ID,Asset type,NWA\n";
+      tempFileContent += `02/01/2024 00:10:33,Dividend,NKE/USD,0.17,-,0.17,"4,581.91",99.60,2272508626,Stocks,0.00,,`;
+
+      // Act
+      sut.processFileContents(tempFileContent, () => { done.fail("Should not succeed!"); }, (err: Error) => {
+
+        // Assert
+        expect(err).toBeTruthy();
+        expect(err.message).toBe("An error ocurred while parsing! Details: Invalid Record Length: columns length is 11, got 13 on line 2");
+
+        done();
+      });
+    });
+
     it("Yahoo Finance throws an error", (done) => {
 
       // Arrange

--- a/src/converters/etoroConverter.ts
+++ b/src/converters/etoroConverter.ts
@@ -49,7 +49,7 @@ export class EtoroConverter extends AbstractConverter {
                 }
 
                 // Parse numbers to floats (from string).
-                if (context.column === "amount" || 
+                if (context.column === "amount" ||
                     context.column === "units") {
 
                     if (context.column === "units" && columnValue === "-") {
@@ -61,11 +61,17 @@ export class EtoroConverter extends AbstractConverter {
 
                 return columnValue;
             }
-        }, async (_, records: EtoroRecord[]) => {
+        }, async (err, records: EtoroRecord[]) => {
 
-            // If records is empty, parsing failed..
-            if (records === undefined || records.length === 0) {                    
-                return errorCallback(new Error("An error ocurred while parsing!"));
+            // Check if parsing failed..
+            if (err || records === undefined || records.length === 0) {
+                let errorMsg = "An error ocurred while parsing!";
+
+                if (err) {
+                    errorMsg += ` Details: ${err.message}`
+                }
+
+                return errorCallback(new Error(errorMsg))
             }
 
             console.log("[i] Read CSV file. Start processing..");
@@ -104,7 +110,7 @@ export class EtoroConverter extends AbstractConverter {
                         quantity: 1,
                         type: GhostfolioOrderType[record.type],
                         unitPrice: feeAmount,
-                        currency: "USD", 
+                        currency: "USD",
                         dataSource: "MANUAL",
                         date: date.format("YYYY-MM-DDTHH:mm:ssZ"),
                         symbol: ""
@@ -128,7 +134,7 @@ export class EtoroConverter extends AbstractConverter {
                         this.progress);
                 }
                 catch (err) {
-                    this.logQueryError(record.details, idx + 2);        
+                    this.logQueryError(record.details, idx + 2);
                     return errorCallback(err);
                 }
 

--- a/src/converters/finpensionConverter.test.ts
+++ b/src/converters/finpensionConverter.test.ts
@@ -77,6 +77,26 @@ describe("finpensionConverter", () => {
       });
     });
 
+    it("the header and row column count doesn't match", (done) => {
+
+      // Arrange
+      const sut = new FinpensionConverter(new SecurityService(new YahooFinanceServiceMock()));
+
+      let tempFileContent = "";
+      tempFileContent += `Date;Category;"Asset Name";ISIN;"Number of Shares";"Asset Currency";"Currency Rate";"Asset Price in CHF";"Cash Flow";Balance\n`;
+      tempFileContent += `2023-07-11;Buy;"CSIF (CH) Bond Corporate Global ex CHF Blue ZBH";CH0189956813;0.001000;CHF;1.000000;821.800000;-0.821800;16.484551;;`;
+
+      // Act
+      sut.processFileContents(tempFileContent, () => { done.fail("Should not succeed!"); }, (err: Error) => {
+
+        // Assert
+        expect(err).toBeTruthy();
+        expect(err.message).toBe("An error ocurred while parsing! Details: Invalid Record Length: columns length is 10, got 12 on line 2");
+
+        done();
+      });
+    });
+
     it("Yahoo Finance throws an error", (done) => {
 
       // Arrange

--- a/src/converters/finpensionConverter.ts
+++ b/src/converters/finpensionConverter.ts
@@ -54,13 +54,19 @@ export class FinpensionConverter extends AbstractConverter {
 
                 return columnValue;
             }
-        }, async (_, records: FinpensionRecord[]) => {
+        }, async (err, records: FinpensionRecord[]) => {
 
-            // If records is empty, parsing failed..
-            if (records === undefined || records.length === 0) {                    
-                return errorCallback(new Error("An error ocurred while parsing!"));
+            // Check if parsing failed..
+            if (err || records === undefined || records.length === 0) {
+                let errorMsg = "An error ocurred while parsing!";
+
+                if (err) {
+                    errorMsg += ` Details: ${err.message}`
+                }
+
+                return errorCallback(new Error(errorMsg))
             }
-        
+
             console.log("[i] Read CSV file. Start processing..");
             const result: GhostfolioExport = {
                 meta: {
@@ -114,8 +120,8 @@ export class FinpensionConverter extends AbstractConverter {
                         record.assetCurrency,
                         this.progress);
                 }
-                catch (err) {                    
-                    this.logQueryError(record.isin || record.assetName, idx + 2);        
+                catch (err) {
+                    this.logQueryError(record.isin || record.assetName, idx + 2);
                     return errorCallback(err);
                 }
 

--- a/src/converters/freetradeConverter.test.ts
+++ b/src/converters/freetradeConverter.test.ts
@@ -77,6 +77,26 @@ describe("freetradeConverter", () => {
         done();
       });
     });
+    
+    it("the header and row column count doesn't match", (done) => {
+
+      // Arrange
+      const sut = new FreetradeConverter(new SecurityService(new YahooFinanceServiceMock()));
+
+      let tempFileContent = "";
+      tempFileContent += "Title,Type,Timestamp,Account Currency,Total Amount,Buy / Sell,Ticker,ISIN,Price per Share in Account Currency,Stamp Duty,Quantity,Venue,Order ID,Order Type,Instrument Currency,Total Shares Amount,Price per Share,FX Rate,Base FX Rate,FX Fee (BPS),FX Fee Amount,Dividend Ex Date,Dividend Pay Date,Dividend Eligible Quantity,Dividend Amount Per Share,Dividend Gross Distribution Amount,Dividend Net Distribution Amount,Dividend Withheld Tax Percentage,Dividend Withheld Tax Amount\n";
+      tempFileContent += `Apple,DIVIDEND,2024-02-15T17:39:00.000Z,GBP,6.78,,AAPL,US0378331005,,,41.83076059,,,,USD,,,,0.79485569,0,0.00,2024-02-09,2024-02-15,41.83076059,0.24000000,10.04,8.53,15,1.51,,`;
+
+      // Act
+      sut.processFileContents(tempFileContent, () => { done("Should not succeed!"); }, (err: Error) => {
+
+        // Assert
+        expect(err).toBeTruthy();
+        expect(err.message).toBe("An error ocurred while parsing! Details: Invalid Record Length: columns length is 29, got 31 on line 2");
+
+        done();
+      });
+    });
 
     it("Yahoo Finance throws an error", (done) => {
 

--- a/src/converters/freetradeConverter.ts
+++ b/src/converters/freetradeConverter.ts
@@ -61,10 +61,17 @@ export class FreetradeConverter extends AbstractConverter {
 
                 return columnValue;
             }
-        }, async (error, records: FreetradeRecord[]) => {
-            // If records is empty, parsing failed..
-            if (records === undefined || records.length === 0 || error) {
-                return errorCallback(new Error("An error ocurred while parsing!\n=> " + error));
+        }, async (err, records: FreetradeRecord[]) => {
+
+            // Check if parsing failed..
+            if (err || records === undefined || records.length === 0) {
+                let errorMsg = "An error ocurred while parsing!";
+
+                if (err) {
+                    errorMsg += ` Details: ${err.message}`
+                }
+
+                return errorCallback(new Error(errorMsg))
             }
 
             console.log("[i] Read CSV file. Start processing..");

--- a/src/converters/ibkrConverter.test.ts
+++ b/src/converters/ibkrConverter.test.ts
@@ -95,6 +95,26 @@ describe("IbkrConverter", () => {
       });
     });
 
+    it("the header and row column count doesn't match", (done) => {
+
+      // Arrange
+      const sut = new IbkrConverter(new SecurityService(new YahooFinanceServiceMock()));
+
+      let tempFileContent = "";
+      tempFileContent += `"Buy/Sell","TradeDate","ISIN","Quantity","TradePrice","TradeMoney","CurrencyPrimary","IBCommission","IBCommissionCurrency"\n`;
+      tempFileContent += `"BUY","20230522","CH0111762537","7","282.7","1978.9","CHF","-5","CHF",,`;
+
+      // Act
+      sut.processFileContents(tempFileContent, () => { done.fail("Should not succeed!"); }, (err: Error) => {
+
+        // Assert
+        expect(err).toBeTruthy();
+        expect(err.message).toBe("An error ocurred while parsing! Details: Invalid Record Length: columns length is 9, got 11 on line 2");
+
+        done();
+      });
+    });
+
     it("Yahoo Finance throws an error", (done) => {
 
       // Arrange

--- a/src/converters/ibkrConverter.ts
+++ b/src/converters/ibkrConverter.ts
@@ -60,11 +60,17 @@ export class IbkrConverter extends AbstractConverter {
 
                 return columnValue;
             }
-        }, async (_, records: IbkrRecord[]) => {
+        }, async (err, records: IbkrRecord[]) => {
 
-            // If records is empty, parsing failed..
-            if (records === undefined || records.length === 0) {
-                return errorCallback(new Error("An error ocurred while parsing!"));
+            // Check if parsing failed..
+            if (err || records === undefined || records.length === 0) {
+                let errorMsg = "An error ocurred while parsing!";
+
+                if (err) {
+                    errorMsg += ` Details: ${err.message}`
+                }
+
+                return errorCallback(new Error(errorMsg))
             }
 
             console.log("[i] Read CSV file. Start processing..");
@@ -226,7 +232,7 @@ export class IbkrConverter extends AbstractConverter {
      * @inheritdoc
      */
     public isIgnoredRecord(record: IbkrRecord): boolean {
-        
+
         return !record.isin;
     }
 

--- a/src/converters/rabobankConverter.test.ts
+++ b/src/converters/rabobankConverter.test.ts
@@ -76,6 +76,26 @@ describe("rabobankConverter", () => {
         done();
       });
     });
+    
+    it("the header and row column count doesn't match", (done) => {
+
+      // Arrange
+      const sut = new RabobankConverter(new SecurityService(new YahooFinanceServiceMock()));
+
+      let tempFileContent = "";
+      tempFileContent += "Portefeuille;Naam;Datum;Type mutatie;Valuta mutatie;Volume;Koers;Valuta koers;Valuta kosten €;Waarde;Bedrag;Isin code;Tijd;Beurs\n";
+      tempFileContent += `12345678;1895 Euro Obligaties Indexfonds;08-02-2024;Koop Fondsen;EUR;1,8726;84,2637 ;EUR;0;157,79;-157,79;NL0014857104;11:46:03.004;Clearstream - Vestima;;`;
+
+      // Act
+      sut.processFileContents(tempFileContent, () => { done.fail("Should not succeed!"); }, (err: Error) => {
+
+        // Assert
+        expect(err).toBeTruthy();
+        expect(err.message).toBe("An error ocurred while parsing! Details: Invalid Record Length: columns length is 14, got 16 on line 2");
+
+        done();
+      });
+    });
 
     it("Yahoo Finance throws an error", (done) => {
 

--- a/src/converters/rabobankConverter.ts
+++ b/src/converters/rabobankConverter.ts
@@ -59,11 +59,17 @@ export class RabobankConverter extends AbstractConverter {
 
                 return columnValue;
             }
-        }, async (_, records: RabobankRecord[]) => {
+        }, async (err, records: RabobankRecord[]) => {
 
-            // If records is empty, parsing failed..
-            if (records === undefined || records.length === 0) {
-                return errorCallback(new Error("An error ocurred while parsing!"));
+            // Check if parsing failed..
+            if (err || records === undefined || records.length === 0) {
+                let errorMsg = "An error ocurred while parsing!";
+
+                if (err) {
+                    errorMsg += ` Details: ${err.message}`
+                }
+
+                return errorCallback(new Error(errorMsg))
             }
 
             console.log("[i] Read CSV file. Start processing..");

--- a/src/converters/schwabConverter.test.ts
+++ b/src/converters/schwabConverter.test.ts
@@ -77,6 +77,26 @@ describe("schwabConverter", () => {
       });
     });
 
+    it("the header and row column count doesn't match", (done) => {
+
+      // Arrange
+      const sut = new SchwabConverter(new SecurityService(new YahooFinanceServiceMock()));
+
+      let tempFileContent = "";
+      tempFileContent += `Date,Action,Symbol,Description,Quantity,Price,Fees & Comm,Amount\n`;
+      tempFileContent += `Transactions Total,,,,,,,"-$26,582.91",,`;
+
+      // Act
+      sut.processFileContents(tempFileContent, () => { done.fail("Should not succeed!"); }, (err: Error) => {
+
+        // Assert
+        expect(err).toBeTruthy();
+        expect(err.message).toBe("An error ocurred while parsing! Details: Invalid Record Length: columns length is 8, got 10 on line 2");
+
+        done();
+      });
+    });
+
     it("Yahoo Finance throws an error", (done) => {
 
       // Arrange

--- a/src/converters/swissquoteConverter.test.ts
+++ b/src/converters/swissquoteConverter.test.ts
@@ -77,6 +77,27 @@ describe("swissquoteConverter", () => {
         done();
       });
     });
+    
+    it("the header and row column count doesn't match", (done) => {
+
+      // Arrange
+      const sut = new SwissquoteConverter(new SecurityService(new YahooFinanceServiceMock()));
+
+      // Create temp file.
+      let tempFileContent = "";
+      tempFileContent += "Date;Order #;Transaction;Symbol;Name;ISIN;Quantity;Unit price;Costs;Accrued Interest;Net Amount;Balance;Currency\n";
+      tempFileContent += "16-06-2022 13:14:35;110152600;Sell;VEUD;VANGUARD FTSE EUROPE UCITS ETF;IE00B945VV12;709.0;32.37;115.28;0.00;22835.05;111207.71;USD;;";
+
+      // Act
+      sut.processFileContents(tempFileContent, () => { fail("Should not succeed!"); }, (err: Error) => {
+
+        // Assert
+        expect(err).toBeTruthy();
+        expect(err.message).toBe("An error ocurred while parsing! Details: Invalid Record Length: columns length is 13, got 15 on line 2");
+
+        done();
+      });
+    });
 
     it("Yahoo Finance throws an error", (done) => {
 

--- a/src/converters/swissquoteConverter.ts
+++ b/src/converters/swissquoteConverter.ts
@@ -62,13 +62,19 @@ export class SwissquoteConverter extends AbstractConverter {
 
                 return columnValue;
             }
-        }, async (_, records: SwissquoteRecord[]) => {
+        }, async (err, records: SwissquoteRecord[]) => {
 
-            // If records is empty, parsing failed..
-            if (records === undefined || records.length === 0) {                    
-                return errorCallback(new Error("An error ocurred while parsing!"));
+            // Check if parsing failed..
+            if (err || records === undefined || records.length === 0) {
+                let errorMsg = "An error ocurred while parsing!";
+
+                if (err) {
+                    errorMsg += ` Details: ${err.message}`
+                }
+
+                return errorCallback(new Error(errorMsg))
             }
-            
+
             console.log("Read CSV file. Start processing..");
             const result: GhostfolioExport = {
                 meta: {
@@ -80,10 +86,10 @@ export class SwissquoteConverter extends AbstractConverter {
 
             // Populate the progress bar.
             const bar1 = this.progress.create(records.length, 0);
-            
+
             for (let idx = 0; idx < records.length; idx++) {
                 const record = records[idx];
-            
+
                 // Check if the record should be ignored.
                 if (this.isIgnoredRecord(record)) {
                     bar1.increment();
@@ -125,7 +131,7 @@ export class SwissquoteConverter extends AbstractConverter {
                         this.progress);
                 }
                 catch (err) {
-                    this.logQueryError(record.isin || record.symbol || record.name, idx + 2);                                                                   
+                    this.logQueryError(record.isin || record.symbol || record.name, idx + 2);
                     return errorCallback(err);
                 }
 
@@ -158,7 +164,7 @@ export class SwissquoteConverter extends AbstractConverter {
             this.progress.stop()
 
             successCallback(result);
-        });      
+        });
     }
 
     /**

--- a/src/converters/trading212Converter.test.ts
+++ b/src/converters/trading212Converter.test.ts
@@ -76,6 +76,26 @@ describe("trading212Converter", () => {
         done();
       });
     });
+    
+    it("the header and row column count doesn't match", (done) => {
+
+      // Arrange
+      const sut = new Trading212Converter(new SecurityService(new YahooFinanceServiceMock()));
+
+      let tempFileContent = "";
+      tempFileContent += "Action,Time,ISIN,Ticker,Name,No. of shares,Price / share,Currency (Price / share),Exchange rate,Result,Currency (Result),Total,Currency (Total),Withholding tax,Currency (Withholding tax),Notes,ID,Currency conversion fee,Currency (Currency conversion fee)\n";
+      tempFileContent += `Market buy,2023-12-18 14:30:03.613,US17275R1023,CSCO,"Cisco Systems",0.0290530000,49.96,USD,1.09303,,"EUR",1.33,"EUR",,,,EOF7504196256,,,,`;
+
+      // Act
+      sut.processFileContents(tempFileContent, () => { done.fail("Should not succeed!"); }, (err: Error) => {
+
+        // Assert
+        expect(err).toBeTruthy();
+        expect(err.message).toBe("An error ocurred while parsing! Details: Invalid Record Length: columns length is 19, got 21 on line 2");
+
+        done();
+      });
+    });
 
     it("Yahoo Finance throws an error", (done) => {
 

--- a/src/converters/trading212Converter.ts
+++ b/src/converters/trading212Converter.ts
@@ -62,11 +62,17 @@ export class Trading212Converter extends AbstractConverter {
 
                 return columnValue;
             }
-        }, async (_, records: Trading212Record[]) => {
+        }, async (err, records: Trading212Record[]) => {
 
-            // If records is empty, parsing failed..
-            if (records === undefined || records.length === 0) {                    
-                return errorCallback(new Error("An error ocurred while parsing!"));
+            // Check if parsing failed..
+            if (err || records === undefined || records.length === 0) {
+                let errorMsg = "An error ocurred while parsing!";
+
+                if (err) {
+                    errorMsg += ` Details: ${err.message}`
+                }
+
+                return errorCallback(new Error(errorMsg))
             }
 
             console.log("[i] Read CSV file. Start processing..");
@@ -123,7 +129,7 @@ export class Trading212Converter extends AbstractConverter {
                         this.progress);
                 }
                 catch (err) {
-                    this.logQueryError(record.isin || record.ticker || record.name, idx + 2);        
+                    this.logQueryError(record.isin || record.ticker || record.name, idx + 2);
                     return errorCallback(err);
                 }
 

--- a/src/converters/xtbConverter.test.ts
+++ b/src/converters/xtbConverter.test.ts
@@ -76,6 +76,27 @@ describe("xtbConverter", () => {
         done();
       });
     });
+    
+    it("the header and row column count doesn't match", (done) => {
+
+      // Arrange
+      const sut = new XtbConverter(new SecurityService(new YahooFinanceServiceMock()));
+
+      let tempFileContent = "";
+      tempFileContent += "ID;Type;Time;Symbol;Comment;Amount\n";
+      
+      tempFileContent += `513492358;Stocks/ETF purchase;11.03.2024 10:05:05;SPYL.DE;OPEN BUY 8 @ 11.2835;-90.27;;`;
+
+      // Act
+      sut.processFileContents(tempFileContent, () => { done.fail("Should not succeed!"); }, (err: Error) => {
+
+        // Assert
+        expect(err).toBeTruthy();
+        expect(err.message).toBe("An error ocurred while parsing! Details: Invalid Record Length: columns length is 6, got 8 on line 2");
+
+        done();
+      });
+    });
 
     it("Yahoo Finance throws an error", (done) => {
 

--- a/src/converters/xtbConverter.ts
+++ b/src/converters/xtbConverter.ts
@@ -55,13 +55,15 @@ export class XtbConverter extends AbstractConverter {
             }
         }, async (err, records: XtbRecord[]) => {
 
-            if (err) {
-                console.log(err);
-            }
+            // Check if parsing failed..
+            if (err || records === undefined || records.length === 0) {
+                let errorMsg = "An error ocurred while parsing!";
 
-            // If records is empty, parsing failed..
-            if (records === undefined || records.length === 0) {
-                return errorCallback(new Error("An error ocurred while parsing!"));
+                if (err) {
+                    errorMsg += ` Details: ${err.message}`
+                }
+
+                return errorCallback(new Error(errorMsg))
             }
 
             console.log("[i] Read CSV file. Start processing..");

--- a/src/manual.ts
+++ b/src/manual.ts
@@ -25,8 +25,9 @@ else {
         inputFile,
         outputFolder,
         () => { process.exit(0); },
-        (error) => {
-            console.log(`[e] Error details: ${error}`);
+        (err) => {
+            console.log("[e] An error ocurred while processing.");
+            console.log(`[e] ${err}`);
             process.exit(99);
         }
     );

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -64,7 +64,7 @@ chokidar
             }, (err) => {
 
                 console.log("[e] An error ocurred while processing.");
-                console.log(`[e] Error details: ${err}`);
+                console.log(`[e] ${err}`);
 
                 // Move file with errors to output folder so it can be fixed manually.
                 console.log("[e] Moving file to output..");


### PR DESCRIPTION
## Fixes

- 🐛 Whenever an error occurs whille parsing a CSV, this error will now be logged to the console.

## Checklist

- [ ] ~Added relevant changes to README (if applicable)~
- [x] Added relevant test(s)
- [x] Updated GitVersion file and corresponding version in `package.json`

## Related issue (if applicable)

Fixes #78 
