### PR TITLE
Allow Ghostfolio to update cash balance

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -28,3 +28,6 @@ DEBUG_LOGGING = false
 
 # Your Ghostfolio secret (with which you log in)
 #GHOSTFOLIO_SECRET = ""
+
+# Update Cash balance when automatically importing
+#GHOSTFOLIO_UPDATE_CASH=false

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 0.15.0
+next-version: 0.16.0
 assembly-informational-format: "{NuGetVersion}"
 mode: ContinuousDeployment
 branches:

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ The repository contains a sample `.env` file. Rename this from `.env.sample`.
   - This can be retrieved by going to Accounts > select your account and copying the ID from the URL 
   
     ![image](https://user-images.githubusercontent.com/5620002/203353840-f5db7323-fb2f-4f4f-befc-e4e340466a74.png)
+- Optionally you can set the `GHOSTFOLIO_UPDATE_CASH` variable to `TRUE` to automatically update your Ghostfolio account cash balance after processing the activities.
 - Optionally you can enable debug logging by setting the `DEBUG_LOGGING` variable to `TRUE`.
 
 You can now run `npm run start [exporttype]`. See the table with run commands below. The tool will open your export and will convert this. It retrieves the symbols that are supported with YAHOO Finance (e.g. for European stocks like `ASML`, it will retrieve `ASML.AS` by the corresponding ISIN).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "export-to-ghostfolio",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "type": "module",
   "description": "Convert multiple broker exports to Ghostfolio import",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "@types/jest": "^29.5.11",
     "@types/node": "^20.14.10",
     "jest": "^29.7.0",
-    "ts-jest": "^29.1.5",
+    "ts-jest": "^29.2.2",
     "ts-node": "^10.9.2",
     "tsx": "^4.16.2",
     "typescript": "^5.5.3"
   },
   "dependencies": {
     "@types/cli-progress": "^3.11.6",
-    "cacache": "^18.0.3",
+    "cacache": "^18.0.4",
     "chokidar": "^3.6.0",
     "cli-progress": "^3.12.0",
     "closest-match": "^1.3.3",

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -32,7 +32,7 @@ async function createAndRunConverter(converterType: string, inputFilePath: strin
     console.log(`[i] Starting Export to Ghostfolio v${packageInfo.version}`);
 
     // If DEBUG_LOGGING is enabled, set spaces to 2 else null for easier to read JSON output.
-    const spaces = `${process.env.DEBUG_LOGGING}` === "true" ? 2 : null;
+    const spaces = `${process.env.DEBUG_LOGGING}`.toLocaleLowerCase() === "true" ? 2 : null;
 
     const converterTypeLc = converterType.toLocaleLowerCase();
 
@@ -43,7 +43,7 @@ async function createAndRunConverter(converterType: string, inputFilePath: strin
     converter.readAndProcessFile(inputFilePath, async (result: GhostfolioExport) => {
 
         // Set cash balance update setting according to settings.
-        result.updateCashBalance = `${process.env.GHOSTFOLIO_UPDATE_CASH}` === "true"
+        result.updateCashBalance = `${process.env.GHOSTFOLIO_UPDATE_CASH}`.toLocaleLowerCase() === "true"
 
         console.log("[i] Processing complete, writing to file..")
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -28,11 +28,11 @@ async function createAndRunConverter(converterType: string, inputFilePath: strin
     if (!process.env.GHOSTFOLIO_ACCOUNT_ID) {
         return errorCallback(new Error("Environment variable GHOSTFOLIO_ACCOUNT_ID not set!"));
     }
-    
+
     console.log(`[i] Starting Export to Ghostfolio v${packageInfo.version}`);
 
     // If DEBUG_LOGGING is enabled, set spaces to 2 else null for easier to read JSON output.
-    const spaces = process.env.DEBUG_LOGGING === "true" ? 2 : null;
+    const spaces = `${process.env.DEBUG_LOGGING}` === "true" ? 2 : null;
 
     const converterTypeLc = converterType.toLocaleLowerCase();
 
@@ -41,6 +41,9 @@ async function createAndRunConverter(converterType: string, inputFilePath: strin
 
     // Map the file to a Ghostfolio import.
     converter.readAndProcessFile(inputFilePath, async (result: GhostfolioExport) => {
+
+        // Set cash balance update setting according to settings.
+        result.updateCashBalance = `${process.env.GHOSTFOLIO_UPDATE_CASH}` === "true"
 
         console.log("[i] Processing complete, writing to file..")
 

--- a/src/converters/abstractconverter.ts
+++ b/src/converters/abstractconverter.ts
@@ -5,7 +5,7 @@ import { SecurityService } from "../securityService";
 export abstract class AbstractConverter {
 
     protected securityService: SecurityService;
-    
+
     protected progress: cliProgress.MultiBar;
 
     constructor(securityService: SecurityService) {
@@ -37,7 +37,7 @@ export abstract class AbstractConverter {
 
         const contents = fs.readFileSync(inputFile, "utf-8");
 
-        this.processFileContents(contents,successCallback, errorCallback);
+        this.processFileContents(contents, successCallback, errorCallback);
     }
 
     /**
@@ -46,7 +46,7 @@ export abstract class AbstractConverter {
      * @param record The record to check
      * @returns true if the record should be skipped, false otherwise.
      */
-    abstract isIgnoredRecord(record: any): boolean;    
+    abstract isIgnoredRecord(record: any): boolean;
 
     /**
      * Process export file contents.
@@ -105,18 +105,18 @@ export abstract class AbstractConverter {
      * @param index The index of the line in the input file.
      */
     protected logQueryError(query: string | undefined, index: number) {
-        
+
         let message = `\n[e] An error ocurred while trying to retrieve {query} (line ${index + 2})!\n`;
-        
+
         if (query) {
             message = message.replace("{query}", `symbol ${query}`);
         } else {
             message = message.replace("{query}", `an empty symbol`);
         }
 
-        console.log(message);    
+        console.log(message);
     }
-    
+
     private camelize(str): string {
         return str.replace(/[^a-zA-Z ]/g, "").replace(/(?:^\w|[A-Z]|\b\w)/g, function (word, index) {
             return index === 0 ? word.toLowerCase() : word.toUpperCase();

--- a/src/converters/investimentalConverter.ts
+++ b/src/converters/investimentalConverter.ts
@@ -1,13 +1,13 @@
 import dayjs from "dayjs";
 import { parse } from "csv-parse";
-import { InvestimentalRecord } from "../models/investimentalRecord";
 import { AbstractConverter } from "./abstractconverter";
 import { SecurityService } from "../securityService";
 import { GhostfolioExport } from "../models/ghostfolioExport";
 import YahooFinanceRecord from "../models/yahooFinanceRecord";
 import customParseFormat from "dayjs/plugin/customParseFormat";
-import { GhostfolioOrderType } from "../models/ghostfolioOrderType";
 import { GhostfolioActivity } from "../models/ghostfolioActivity";
+import { InvestimentalRecord } from "../models/investimentalRecord";
+import { GhostfolioOrderType } from "../models/ghostfolioOrderType";
 
 export class InvestimentalConverter extends AbstractConverter {
 
@@ -86,7 +86,7 @@ export class InvestimentalConverter extends AbstractConverter {
                         bar1.increment();
                         continue;
                     }
-                
+
                     let security: YahooFinanceRecord;
                     try {
                         security = await this.securityService.getSecurity(
@@ -115,9 +115,9 @@ export class InvestimentalConverter extends AbstractConverter {
                 bar1.increment();
             }
 
-        this.progress.stop()
+            this.progress.stop()
 
-        successCallback(result);
+            successCallback(result);
         });
     }
 
@@ -153,24 +153,24 @@ export class InvestimentalConverter extends AbstractConverter {
         let totalValue = 0;
         let lastFee = 0;
         let lastPrice = 0;
-    
+
         for (const record of orderRecords) {
             if (record.updateType === "Fil") {
                 let newlyExecutedVolume = remainingVolume - record.volume;
                 if (record.status === "Inactive") {
                     newlyExecutedVolume = record.volume;
-                }                
+                }
                 executedVolume += newlyExecutedVolume;
-                totalValue += newlyExecutedVolume * (record.price || lastPrice);                
+                totalValue += newlyExecutedVolume * (record.price || lastPrice);
             }
-            
+
             lastFee = record.fee || lastFee;
             lastPrice = record.price || lastPrice;
             remainingVolume = record.volume;
         }
-    
+
         const lastRecord = orderRecords[orderRecords.length - 1];
-    
+
         if (executedVolume > 0) {
             const averagePrice = totalValue > 0 ? Number((totalValue / executedVolume).toFixed(4)) : lastPrice;
             return {
@@ -181,7 +181,7 @@ export class InvestimentalConverter extends AbstractConverter {
 
             };
         }
-    
+
         return null;
     }
 

--- a/src/models/ghostfolioActivity.ts
+++ b/src/models/ghostfolioActivity.ts
@@ -10,5 +10,5 @@ export class GhostfolioActivity {
     currency: string;
     dataSource: string;
     date: string;
-    symbol: string
+    symbol: string;
 }

--- a/src/models/ghostfolioExport.ts
+++ b/src/models/ghostfolioExport.ts
@@ -3,6 +3,7 @@ import { GhostfolioActivity } from "./ghostfolioActivity";
 class GhostfolioExport {
     meta: GhostfolioMeta;
     activities: GhostfolioActivity[];
+    updateCashBalance: boolean;
 }
 
 class GhostfolioMeta {

--- a/src/models/ghostfolioExport.ts
+++ b/src/models/ghostfolioExport.ts
@@ -3,7 +3,7 @@ import { GhostfolioActivity } from "./ghostfolioActivity";
 class GhostfolioExport {
     meta: GhostfolioMeta;
     activities: GhostfolioActivity[];
-    updateCashBalance: boolean;
+    updateCashBalance?: boolean;
 }
 
 class GhostfolioMeta {


### PR DESCRIPTION
## Added

- ✨ New setting called `GHOSTFOLIO_UPDATE_CASH` which sets `updateCashBalance` to `true` in the generated export, allowing Ghostfolio to automatically update your internal cash balance 
 
## Fixes

- 🏗️ Updated some dependencies

## Checklist

- [x] Added relevant changes to README (if applicable)
- [ ] ~Added relevant test(s)~
- [x] Updated GitVersion file and corresponding version in `package.json`

## Related issue (if applicable)

Fixes #87 
