### PR TITLE
Converters take Yahoo Finance currency over export currency

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 0.17.0
+next-version: 0.17.1
 assembly-informational-format: "{NuGetVersion}"
 mode: ContinuousDeployment
 branches:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "export-to-ghostfolio",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "type": "module",
   "description": "Convert multiple broker exports to Ghostfolio import",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
   "devDependencies": {
     "@types/cacache": "^17.0.2",
     "@types/jest": "^29.5.11",
-    "@types/node": "^20.14.10",
+    "@types/node": "^22.3.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.2",
     "ts-node": "^10.9.2",
-    "tsx": "^4.16.2",
-    "typescript": "^5.5.3"
+    "tsx": "^4.17.0",
+    "typescript": "^5.5.4"
   },
   "dependencies": {
     "@types/cli-progress": "^3.11.6",
@@ -30,7 +30,7 @@
     "cli-progress": "^3.12.0",
     "closest-match": "^1.3.3",
     "csv-parse": "^5.5.6",
-    "dayjs": "^1.11.11",
+    "dayjs": "^1.11.12",
     "dotenv": "^16.4.5",
     "yahoo-finance2": "^2.11.3"
   }

--- a/src/converters/buxConverter.ts
+++ b/src/converters/buxConverter.ts
@@ -157,7 +157,7 @@ export class BuxConverter extends AbstractConverter {
                     quantity: quantity,
                     type: GhostfolioOrderType[record.transactionType],
                     unitPrice: unitPrice,
-                    currency: record.transactionCurrency,
+                    currency: security.currency ?? record.transactionCurrency,
                     dataSource: "YAHOO",
                     date: dayjs(record.transactionTimeCet).format("YYYY-MM-DDTHH:mm:ssZ"),
                     symbol: security.symbol

--- a/src/converters/etoroConverter.ts
+++ b/src/converters/etoroConverter.ts
@@ -155,7 +155,7 @@ export class EtoroConverter extends AbstractConverter {
                     quantity: record.units,
                     type: GhostfolioOrderType[record.type],
                     unitPrice: unitPrice,
-                    currency: currency,
+                    currency: security.currency ?? currency,
                     dataSource: "YAHOO",
                     date: date.format("YYYY-MM-DDTHH:mm:ssZ"),
                     symbol: security.symbol

--- a/src/converters/finpensionConverter.ts
+++ b/src/converters/finpensionConverter.ts
@@ -150,7 +150,7 @@ export class FinpensionConverter extends AbstractConverter {
                     quantity: numberOfShares,
                     type: GhostfolioOrderType[record.category],
                     unitPrice: assetPriceInChf,
-                    currency: record.assetCurrency,
+                    currency: security.currency ?? record.assetCurrency,
                     dataSource: "YAHOO",
                     date: dayjs(record.date).format("YYYY-MM-DDTHH:mm:ssZ"),
                     symbol: security.symbol

--- a/src/converters/ibkrConverter.ts
+++ b/src/converters/ibkrConverter.ts
@@ -181,7 +181,7 @@ export class IbkrConverter extends AbstractConverter {
                     quantity: quantity,
                     type: type,
                     unitPrice: price,
-                    currency: currency,
+                    currency: security.currency ?? currency,
                     dataSource: "YAHOO",
                     date: date.format("YYYY-MM-DDTHH:mm:ssZ"),
                     symbol: security.symbol

--- a/src/converters/rabobankConverter.ts
+++ b/src/converters/rabobankConverter.ts
@@ -169,7 +169,7 @@ export class RabobankConverter extends AbstractConverter {
                     quantity: quantity,
                     type: GhostfolioOrderType[record.type],
                     unitPrice: price,
-                    currency: record.currency,
+                    currency: security.currency ?? record.currency,
                     dataSource: "YAHOO",
                     date: date.format("YYYY-MM-DDTHH:mm:ssZ"),
                     symbol: security.symbol

--- a/src/converters/swissquoteConverter.ts
+++ b/src/converters/swissquoteConverter.ts
@@ -152,7 +152,7 @@ export class SwissquoteConverter extends AbstractConverter {
                     quantity: record.quantity,
                     type: GhostfolioOrderType[record.transaction],
                     unitPrice: record.unitPrice,
-                    currency: record.netAmountCurrency ?? record.currency,
+                    currency: security.currency ?? record.netAmountCurrency ?? record.currency,
                     dataSource: "YAHOO",
                     date: date.format("YYYY-MM-DDTHH:mm:ssZ"),
                     symbol: security.symbol

--- a/src/converters/trading212Converter.ts
+++ b/src/converters/trading212Converter.ts
@@ -148,7 +148,7 @@ export class Trading212Converter extends AbstractConverter {
                     quantity: record.noOfShares,
                     type: GhostfolioOrderType[record.action],
                     unitPrice: record.priceShare,
-                    currency: record.currencyPriceShare,
+                    currency: security.currency ?? record.currencyPriceShare,
                     dataSource: "YAHOO",
                     date: dayjs(record.time).format("YYYY-MM-DDTHH:mm:ssZ"),
                     symbol: security.symbol

--- a/src/converters/xtbConverter.ts
+++ b/src/converters/xtbConverter.ts
@@ -143,7 +143,7 @@ export class XtbConverter extends AbstractConverter {
                     quantity: quantity,
                     type: GhostfolioOrderType[record.type],
                     unitPrice: unitPrice,
-                    currency: security.currency,
+                    currency: security.currency ?? security.currency,
                     dataSource: "YAHOO",
                     date: date.format("YYYY-MM-DDTHH:mm:ssZ"),
                     symbol: security.symbol,


### PR DESCRIPTION
## Fixes

- 🏗️ All relevant converters now take the Yahoo Finance currency that is linked to the security over the currency in the export
- 🏗️ Updated dependencies

## Checklist

- [ ] ~Added relevant changes to README (if applicable)~
- [ ] ~Added relevant test(s)~
- [x] Updated GitVersion file and corresponding version in `package.json`

## Related issue (if applicable)

Fixes #100 