### PR TITLE
Round the `filesToProduce` count UP to the nearest integer

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 0.29.1
+next-version: 0.29.2
 assembly-informational-format: "{NuGetVersion}"
 mode: ContinuousDeployment
 branches:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "export-to-ghostfolio",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/cli-progress": "^3.11.6",

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -57,7 +57,7 @@ async function createAndRunConverter(converterType: string, inputFilePath: strin
 
         // Check if the output needs to be split into chunks. If so, calculate how many files need to be produced.
         const splitOutput = `${process.env.GHOSTFOLIO_SPLIT_OUTPUT}`.toLocaleLowerCase() === "true";
-        const filesToProduce = !splitOutput ? 1 : Math.round(result.activities.length / 25);
+        const filesToProduce = !splitOutput ? 1 : Math.ceil(result.activities.length / 25);
 
         console.log(`[i] Processing complete, writing to ${filesToProduce === 1 ? "file" : filesToProduce + " files"}..`);
 


### PR DESCRIPTION
 e.g:
For an import file with 1 activity, `filesToProduce` = 1 
For an import file with 26 activities, `filesToProduce` = 2

NOTE:  I have not added any tests.  

## Checklist

- [ ] Added relevant changes to README (if applicable)
- [ ] Added relevant test(s)
- [x] Updated GitVersion file and corresponding version in `package.json`

## Related issue

Fixes #198 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the software version to 0.29.2.
  
- **Bug Fixes**
  - Adjusted the output splitting process to ensure that all segments are properly generated when data does not evenly divide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->