### PR TITLE
Saxo fractional shares

### DIFF
--- a/samples/saxo-export.csv
+++ b/samples/saxo-export.csv
@@ -27,5 +27,5 @@ Client ID,Trade Date,Value Date,Type,Instrument,Instrument ISIN,Instrument curre
 ,16-Dec-2024,16-Dec-2024,Cash Transfer,,,USD,Unknown,,Deposit,280,,1
 ,16-Dec-2024,18-Dec-2024,Trade,Vanguard FTSE All-World UCITS ETF,IE00BK5BQT80,USD,London Stock Exchange (ETFs),VWRA:xlon,Buy 2 @ 142.58 USD,"-288,96",,1
 ,16-Dec-2024,18-Dec-2024,Trade,Vanguard FTSE All-World UCITS ETF,IE00BK5BQT80,USD,London Stock Exchange (ETFs),VWRA:xlon,Buy 2 @ 142.58 USD,"-288,96",,1
-,16-jan-2025,20-jan-2025,Transactie,Vanguard S&P 500 Dist UCITS ETF,IE00B3XXRP09,EUR,Euronext Amsterdam,VUSA:xams,Koop 1 @ 110.01 EUR,-110,,1
+,16-jan-2025,20-jan-2025,Transactie,Vanguard S&P 500 Dist UCITS ETF,IE00B3XXRP09,EUR,Euronext Amsterdam,VUSA:xams,Koop 1.5 @ 110.01 EUR,-110,,1
 ,16-Dec-2024,16-Dec-2024,Cash Transfer,,,USD,Unknown,,Withdrawal,-280,,1

--- a/src/converters/saxoConverter.ts
+++ b/src/converters/saxoConverter.ts
@@ -138,7 +138,7 @@ export class SaxoConverter extends AbstractConverter {
                     }
                     else {
 
-                        const actionDetails = record.event.match(/(\d+)\s+@\s+([\d.]+)/)
+                        const actionDetails = record.event.match(/(\d+(?:\.\d+)?)\s+@\s+([\d.]+)/)
 
                         // Make negative numbers (on sell records) absolute.
                         numberOfShares = parseFloat(actionDetails[1]);


### PR DESCRIPTION
Saxo supports fractional shares for ETF's which wheres handled by the regex.
 
## Fixes
- Changed regex to support fractional amounts for Saxo transactions

## Checklist

- [x] Added relevant test(s)
- [?] Updated the GitVersion file (if not done automatically)