### PR TITLE
finpension comment default value to be null instead of ""

### DIFF
--- a/src/converters/finpensionConverter.ts
+++ b/src/converters/finpensionConverter.ts
@@ -102,7 +102,7 @@ export class FinpensionConverter extends AbstractConverter {
                         // Add fees record to export.
                         result.activities.push({
                             accountId: process.env.GHOSTFOLIO_ACCOUNT_ID,
-                            comment: "",
+                            comment: null,
                             fee: feeAmount,
                             quantity: 1,
                             type: GhostfolioOrderType[record.category],
@@ -151,7 +151,7 @@ export class FinpensionConverter extends AbstractConverter {
                     // Add record to export.
                     result.activities.push({
                         accountId: process.env.GHOSTFOLIO_ACCOUNT_ID,
-                        comment: "",
+                        comment: null,
                         fee: 0,
                         quantity: numberOfShares,
                         type: GhostfolioOrderType[record.category],


### PR DESCRIPTION
## Added

- Nothing
 
## Fixes

- Duplicated finpension transaction detection by initializing the empty `comment` value of the activity `.json` with `null` instead of `""`.

## Checklist

- [X] Added relevant changes to README (if applicable)
- [X] Added relevant test(s)
- [?] Updated the GitVersion file (if not done automatically)

## Related issue (if applicable)

Fixes #..
