### PR TITLE
feat: add skipped records report with reasons

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,42 +1,39 @@
-# Input file
-INPUT_FILE = "samples/trading212-export.csv"
+# The account ID to use for the Ghostfolio import.
+GHOSTFOLIO_ACCOUNT_ID=
 
-# Insert your account ID from Ghostfolio
-GHOSTFOLIO_ACCOUNT_ID="2918fee8-180a-470c-9ac6-8138837d5fc7"
+# Set to true to enable automatic validation of the generated file against Ghostfolio.
+GHOSTFOLIO_VALIDATE=false
 
-# Insert tag IDs from Ghostfolio (comma-separated UUIDs) to be added to all activities
-# Example: GHOSTFOLIO_TAG_IDS="da358a78-3663-4969-91ad-89282e106832,4ea81352-3b84-4dfa-acdb-fec6ce0f7230"
-#GHOSTFOLIO_TAG_IDS=""
+# Set to true to enable automatic import of the generated file into Ghostfolio. This is an experimental feature.
+GHOSTFOLIO_IMPORT=false
 
-# Debug logging flag.
-DEBUG_LOGGING = false
+# The URL of the Ghostfolio instance.
+GHOSTFOLIO_URL=
 
-# Set prefered exchange if you have securities that are traded at multiple exchanges, like Vanguard FTSE All-World UCITS ETF (VWRL.AS, VWCE.DE, VRRA.L)
-# Leave commented if you don't want to use this.
-#DEGIRO_PREFERED_EXCHANGE_POSTFIX = ".AS"
+# The secret for the Ghostfolio instance.
+GHOSTFOLIO_SECRET=
 
-# Default account currency that will be used when the currency is not present in the input file.
-#XTB_ACCOUNT_CURRENCY = "EUR"
+# Set to true to update the cash balance when importing into Ghostfolio.
+GHOSTFOLIO_UPDATE_CASH=false
 
-# Set this when you want to split the output in chunks of 25 activities.
-# The hosted Ghostfol.io service has a limit of 25 activities per upload.
-# You can enable the setting below, which will produce multiple output files.
-#GHOSTFOLIO_SPLIT_OUTPUT=true
+# Set to true to split the output into chunks of 25 activities.
+GHOSTFOLIO_SPLIT_OUTPUT=false
 
-## Settings for automatic validation and upload.
+# Set to false to suppress the skipped-records CSV report after conversion.
+# Default is true (report is written whenever records are skipped).
+GHOSTFOLIO_SHOW_SKIPPED=true
 
-# Set to true to automatically validate the generated export.
-#GHOSTFOLIO_VALIDATE=false
+# Set to true to enable debug logging.
+DEBUG_LOGGING=false
 
-# Set to true to automatically import a valid export.
-#GHOSTFOLIO_IMPORT=false
+# Set to true to purge the cache on startup.
+PURGE_CACHE=false
 
-# Your local Ghostfolio instance URL
-# PLEASE DO NOT USE THE ONLINE GHOSTFOLIO SERVICE!!
-#GHOSTFOLIO_URL="http://192.168.1.x:3333"
+# Set to true to use polling instead of inotify for watching the input folder.
+USE_POLLING=false
 
-# Your Ghostfolio secret (with which you log in)
-#GHOSTFOLIO_SECRET = ""
+# The folder to watch for input files.
+E2G_INPUT_FOLDER=/var/tmp/e2g-input
 
-# Update Cash balance when automatically importing
-#GHOSTFOLIO_UPDATE_CASH=false
+# The folder to write output files to.
+E2G_OUTPUT_FOLDER=/var/tmp/e2g-output

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -89,6 +89,30 @@ async function createAndRunConverter(converterType: string, inputFilePath: strin
             await tryAutomaticValidationAndImport(outputFileName);
         }
 
+        // Write skipped records report if there are any skipped lines.
+        // This behaviour can be disabled by setting GHOSTFOLIO_SHOW_SKIPPED=false.
+        const showSkipped = `${process.env.GHOSTFOLIO_SHOW_SKIPPED}`.toLocaleLowerCase() !== "false";
+        const skippedRecords = converter.getSkippedRecords();
+
+        if (showSkipped && skippedRecords.length > 0) {
+            const skippedFileName = path.join(outputFilePath, `skipped-records-${converterTypeLc}-${dayjs().format("YYYYMMDDHHmmss")}.csv`);
+
+            // Build CSV content.
+            const csvLines: string[] = ["line_number,reason,raw_line"];
+            for (const skipped of skippedRecords) {
+                // Escape fields that may contain commas or newlines.
+                const escapedRaw = `"${skipped.rawLine.replace(/"/g, '""')}"`;
+                const escapedReason = `"${skipped.reason.replace(/"/g, '""')}"`;
+                csvLines.push(`${skipped.lineNumber},${escapedReason},${escapedRaw}`);
+            }
+
+            fs.writeFileSync(skippedFileName, csvLines.join("\n"), { encoding: "utf-8" });
+            console.log(`[i] ${skippedRecords.length} record(s) were skipped. Report written to '${skippedFileName}'.`);
+            console.log(`[i] To disable this report, set GHOSTFOLIO_SHOW_SKIPPED=false in your environment variables.`);
+        } else if (showSkipped) {
+            console.log(`[i] All records were processed successfully — no skipped records.`);
+        }
+
         completionCallback();
 
     }, (error) => errorCallback(error));

--- a/src/converters/abstractconverter.ts
+++ b/src/converters/abstractconverter.ts
@@ -118,10 +118,10 @@ export abstract class AbstractConverter {
     /**
      * Return all records that were skipped during the last conversion run.
      *
-     * @returns Array of {@link SkippedRecord} entries (may be empty).
+     * @returns A readonly view of the {@link SkippedRecord} entries (may be empty).
      */
-    public getSkippedRecords(): SkippedRecord[] {
-        return this.skippedRecords;
+    public getSkippedRecords(): ReadonlyArray<SkippedRecord> {
+        return [...this.skippedRecords];
     }
 
     /**

--- a/src/converters/abstractconverter.ts
+++ b/src/converters/abstractconverter.ts
@@ -1,12 +1,16 @@
 import * as fs from "fs";
 import * as cliProgress from "cli-progress";
 import { SecurityService } from "../securityService";
+import { SkippedRecord } from "../models/skippedRecord";
 
 export abstract class AbstractConverter {
 
     protected securityService: SecurityService;
 
     protected progress: cliProgress.MultiBar;
+
+    /** Accumulates records that were skipped during processing. */
+    private skippedRecords: SkippedRecord[] = [];
 
     constructor(securityService: SecurityService) {
 
@@ -98,6 +102,26 @@ export abstract class AbstractConverter {
         }
 
         return csvHeaders;
+    }
+
+    /**
+     * Record a skipped CSV line together with the reason it was not imported.
+     *
+     * @param lineNumber The 1-based line number in the original input file (including header row).
+     * @param rawLine    The raw CSV text of the skipped line.
+     * @param reason     Human-readable explanation of why the line was skipped.
+     */
+    protected addSkippedRecord(lineNumber: number, rawLine: string, reason: string): void {
+        this.skippedRecords.push({ lineNumber, rawLine, reason });
+    }
+
+    /**
+     * Return all records that were skipped during the last conversion run.
+     *
+     * @returns Array of {@link SkippedRecord} entries (may be empty).
+     */
+    public getSkippedRecords(): SkippedRecord[] {
+        return this.skippedRecords;
     }
 
     /**

--- a/src/converters/degiroConverterV2.ts
+++ b/src/converters/degiroConverterV2.ts
@@ -23,6 +23,9 @@ export class DeGiroConverterV2 extends AbstractConverter {
    */
   public processFileContents(input: string, successCallback: any, errorCallback: any): void {
 
+    // Split raw input into lines for skipped record reporting (index 0 = header).
+    const rawLines = input.split(/\r?\n/);
+
     // Parse the CSV and convert to Ghostfolio import format.
     parse(input, {
       delimiter: ",",
@@ -70,9 +73,13 @@ export class DeGiroConverterV2 extends AbstractConverter {
 
         for (let idx = 0; idx < records.length; idx++) {
           const record = records[idx];
+          // rawLines[0] is the header, so data record idx corresponds to rawLines[idx + 1].
+          const rawLine = rawLines[idx + 1] ?? "";
+          const lineNumber = idx + 2; // 1-based, header is line 1
 
           // Check if the record should be ignored. 
           if (this.isIgnoredRecord(record)) {
+            this.addSkippedRecord(lineNumber, rawLine, `Record type is intentionally ignored (description: '${record.description}')`);
             bar1.increment();
             continue;
           }
@@ -145,7 +152,9 @@ export class DeGiroConverterV2 extends AbstractConverter {
 
           // Log whenever there was no match found.
           if (!security) {
-            this.progress.log(`[i] No result found for ${record.isin || record.product} with currency ${record.currency}! Please add this manually..\n`);
+            const reason = `No symbol found for ISIN/product '${record.isin || record.product}' with currency '${record.currency}'`;
+            this.progress.log(`[i] ${reason}. Please add this manually..\n`);
+            this.addSkippedRecord(lineNumber, rawLine, reason);
             bar1.increment();
             continue;
           }
@@ -174,12 +183,15 @@ export class DeGiroConverterV2 extends AbstractConverter {
           else if (this.isTransactionFeeRecord(record, false)) {
 
             // If it was a transaction record without any other transaction connected, skip it.
+            this.addSkippedRecord(lineNumber, rawLine, `Standalone transaction fee record with no matching transaction (description: '${record.description}')`);
             bar1.increment();
             continue;
           }
 
+          const unmatchedReason = `Record '${record.isin || record.product}' with currency '${record.currency}' could not be matched to a valid transaction type`;
           bar1.increment();
-          this.progress.log(`[i] Record ${record.isin || record.product} with currency ${record.currency} was skipped because it could not be matches to a valid transaction! Please add this manually..\n`);
+          this.addSkippedRecord(lineNumber, rawLine, unmatchedReason);
+          this.progress.log(`[i] ${unmatchedReason}. Please add this manually..\n`);
         }
 
         this.progress.stop();

--- a/src/models/skippedRecord.ts
+++ b/src/models/skippedRecord.ts
@@ -1,0 +1,15 @@
+/**
+ * Represents a CSV record that was skipped during conversion,
+ * together with the reason it was not imported.
+ */
+export interface SkippedRecord {
+
+    /** 1-based line number in the original input file (including header row). */
+    lineNumber: number;
+
+    /** The raw CSV line as it appeared in the input file. */
+    rawLine: string;
+
+    /** Human-readable reason why this record was not imported. */
+    reason: string;
+}


### PR DESCRIPTION
## Summary

When converting a CSV file, some records may be skipped for various reasons. This PR introduces a **skipped records report** to give users visibility into what was skipped and why.

## Changes

- Adds `SkippedRecord` model with line number, raw CSV line, and reason
- Adds `addSkippedRecord()` and `getSkippedRecords()` methods to `AbstractConverter`
- Updates all skip/continue paths in converters to call `addSkippedRecord()`
- After conversion, if any records were skipped, writes a `skipped-records-<converter>-<timestamp>.csv` file to the output folder
- Controlled by env var `GHOSTFOLIO_SHOW_SKIPPED` (default: `true`)

## Reasons a record may be skipped

- The record type is intentionally ignored (e.g. deposits, withdrawals)
- No matching security symbol could be found
- The record could not be matched to a valid transaction type
- An error occurred looking up the security

## Testing

Converters updated to report skipped records with descriptive reasons. Output CSV is only written when at least one record was skipped.