### PR TITLE
DEGIRO: Add Spanish translations for platform fees and money-market fund conversions

### DIFF
--- a/src/converters/degiroConverterV2.test.ts
+++ b/src/converters/degiroConverterV2.test.ts
@@ -169,32 +169,42 @@ describe("degiroConverterV2", () => {
       new DeGiroConverterV2(new SecurityService(new YahooFinanceServiceMock())) as any;
 
     // Each row: [classifier method name, description, args after the record, expected].
-    // Lowercase + uppercase variants per keyword to lock in lowercase normalization.
+    // Lowercase + uppercase variants per keyword lock in lowercase normalization.
     it.each([
-      // isIgnoredRecord — "fondos del mercado monetario"
       ["isIgnoredRecord", "Conversión fondos del mercado monetario: Compra 0,002521 @ 9.915,9121 EUR", [], true],
       ["isIgnoredRecord", "CONVERSIÓN FONDOS DEL MERCADO MONETARIO: Venta 0,001063 @ 9.912,2063 EUR", [], true],
-
-      // isPlatformFees — "comisión de conectividad"
       ["isPlatformFees", "Comisión de conectividad con el mercado 2024 (New York Stock Exchange - NSY)", [], true],
       ["isPlatformFees", "COMISIÓN DE CONECTIVIDAD con el mercado 2025 (Xetra - XET)", [], true],
-
-      // isTransactionFeeRecord (buy/sell context) — "y/o"
       ["isTransactionFeeRecord", "Costes de transacción y/o externos de DEGIRO", [true], true],
       ["isTransactionFeeRecord", "COSTES DE TRANSACCIÓN Y/O EXTERNOS DE DEGIRO", [true], true],
-
-      // isTransactionFeeRecord (dividend context) — "retención del dividendo"
       ["isTransactionFeeRecord", "Retención del dividendo", [false], true],
       ["isTransactionFeeRecord", "RETENCIÓN DEL DIVIDENDO", [false], true],
-
-      // isDividendRecord — "rendimiento de capital"
       ["isDividendRecord", "Rendimiento de capital", [], true],
       ["isDividendRecord", "RENDIMIENTO DE CAPITAL", [], true],
+
+      // Negative cases: real-trade and unrelated phrases must not be misclassified.
+      ["isIgnoredRecord", "Compra 1 Telefonica SA@3,937 EUR (ES0178430E18)", [], false],
+      ["isIgnoredRecord", "Dividendo", [], false],
+      ["isPlatformFees", "Costes de transacción y/o externos de DEGIRO", [], false],
+      ["isPlatformFees", "compra 1 alphabet inc class a@164,16 usd", [], false],
+      ["isDividendRecord", "Costes de transacción y/o externos de DEGIRO", [], false],
+      ["isDividendRecord", "COMPRA 1 Telefonica SA@3,937 EUR", [], false],
+      ["isTransactionFeeRecord", "Dividendo", [false], false],
+      ["isTransactionFeeRecord", "Compra 1 Telefonica SA@3,937 EUR", [true], false],
     ] as const)("%s(%s) === %s", (method, description, extraArgs, expected) => {
 
       const sut = newSut();
       const result = sut[method](record(description), ...extraArgs);
       expect(result).toBe(expected);
+    });
+
+    // Dividend-context orderId guard: a real fee phrase still returns false when
+    // paired with a non-empty orderId (V2 line 442 early-return).
+    it("isTransactionFeeRecord returns false for a dividend fee with non-empty orderId", () => {
+
+      const sut = newSut();
+      const result = sut.isTransactionFeeRecord(record("Retención del dividendo", "abc-123"), false);
+      expect(result).toBe(false);
     });
   });
 

--- a/src/converters/degiroConverterV2.test.ts
+++ b/src/converters/degiroConverterV2.test.ts
@@ -148,6 +148,56 @@ describe("degiroConverterV2", () => {
     }, () => done.fail("Should not have an error!"));
   });
 
+  describe("Spanish keyword classification", () => {
+
+    const record = (description: string, orderId = "") => ({
+      date: "01-01-2024",
+      time: "12:00",
+      currencyDate: "01-01-2024",
+      product: "TEST",
+      isin: "TEST",
+      description,
+      fx: "",
+      currency: "EUR",
+      amount: "1,00",
+      col1: "",
+      col2: "",
+      orderId
+    }) as any;
+
+    const newSut = () =>
+      new DeGiroConverterV2(new SecurityService(new YahooFinanceServiceMock())) as any;
+
+    // Each row: [classifier method name, description, args after the record, expected].
+    // Lowercase + uppercase variants per keyword to lock in lowercase normalization.
+    it.each([
+      // isIgnoredRecord — "fondos del mercado monetario"
+      ["isIgnoredRecord", "Conversión fondos del mercado monetario: Compra 0,002521 @ 9.915,9121 EUR", [], true],
+      ["isIgnoredRecord", "CONVERSIÓN FONDOS DEL MERCADO MONETARIO: Venta 0,001063 @ 9.912,2063 EUR", [], true],
+
+      // isPlatformFees — "comisión de conectividad"
+      ["isPlatformFees", "Comisión de conectividad con el mercado 2024 (New York Stock Exchange - NSY)", [], true],
+      ["isPlatformFees", "COMISIÓN DE CONECTIVIDAD con el mercado 2025 (Xetra - XET)", [], true],
+
+      // isTransactionFeeRecord (buy/sell context) — "y/o"
+      ["isTransactionFeeRecord", "Costes de transacción y/o externos de DEGIRO", [true], true],
+      ["isTransactionFeeRecord", "COSTES DE TRANSACCIÓN Y/O EXTERNOS DE DEGIRO", [true], true],
+
+      // isTransactionFeeRecord (dividend context) — "retención del dividendo"
+      ["isTransactionFeeRecord", "Retención del dividendo", [false], true],
+      ["isTransactionFeeRecord", "RETENCIÓN DEL DIVIDENDO", [false], true],
+
+      // isDividendRecord — "rendimiento de capital"
+      ["isDividendRecord", "Rendimiento de capital", [], true],
+      ["isDividendRecord", "RENDIMIENTO DE CAPITAL", [], true],
+    ] as const)("%s(%s) === %s", (method, description, extraArgs, expected) => {
+
+      const sut = newSut();
+      const result = sut[method](record(description), ...extraArgs);
+      expect(result).toBe(expected);
+    });
+  });
+
   it("should log error and invoke errorCallback when an error occurs in processFileContents", (done) => {
   
     // Arrange

--- a/src/converters/degiroConverterV2.ts
+++ b/src/converters/degiroConverterV2.ts
@@ -429,7 +429,7 @@ export class DeGiroConverterV2 extends AbstractConverter {
       return false;
     }
 
-    return record.description.toLocaleLowerCase().indexOf("dividend") > -1 || record.description.toLocaleLowerCase().indexOf("capital return") > -1;
+    return record.description.toLocaleLowerCase().indexOf("dividend") > -1 || record.description.toLocaleLowerCase().indexOf("capital return") > -1 || record.description.toLocaleLowerCase().indexOf("rendimiento de capital") > -1;
   }
 
   private isTransactionFeeRecord(record: DeGiroRecord, isBuyOrSellTransactionFeeRecord: boolean): boolean {
@@ -443,7 +443,7 @@ export class DeGiroConverterV2 extends AbstractConverter {
       return false;
     }
 
-    const transactionFeeRecordType = ["en\/of", "and\/or", "und\/oder", "e\/o", "adr\/gdr", "ritenuta", "belasting", "daň z dividendy", "taxe sur les", "impôts sur", "comissões de transação", "courtage et/ou"];
+    const transactionFeeRecordType = ["en\/of", "and\/or", "und\/oder", "e\/o", "y\/o", "adr\/gdr", "ritenuta", "belasting", "daň z dividendy", "taxe sur les", "impôts sur", "comissões de transação", "courtage et/ou", "retención del dividendo"];
 
     return transactionFeeRecordType.some((t) => record.description.toLocaleLowerCase().indexOf(t) > -1);
   }

--- a/src/converters/degiroConverterV2.ts
+++ b/src/converters/degiroConverterV2.ts
@@ -257,7 +257,8 @@ export class DeGiroConverterV2 extends AbstractConverter {
       "retirada",
       "levantamento de divisa",
       "dito de divisa",
-      "fonds monétaires"];
+      "fonds monétaires",
+      "fondos del mercado monetario"];
 
     return ignoredRecordTypes.some((t) => record.description.toLocaleLowerCase().indexOf(t) > -1);
   }
@@ -449,7 +450,7 @@ export class DeGiroConverterV2 extends AbstractConverter {
 
   private isPlatformFees(record: DeGiroRecord): boolean {
 
-    const platformFeeRecordType = ["aansluitingskosten", "connection fee", "costi di connessione", "verbindungskosten", "custo de conectividade", "frais de connexion", "juros", "corporate action"];
+    const platformFeeRecordType = ["aansluitingskosten", "connection fee", "costi di connessione", "verbindungskosten", "custo de conectividade", "frais de connexion", "comisión de conectividad", "juros", "corporate action"];
 
     return platformFeeRecordType.some((t) => record.description.toLocaleLowerCase().indexOf(t) > -1);
   }

--- a/src/converters/degiroConverterV3.test.ts
+++ b/src/converters/degiroConverterV3.test.ts
@@ -179,6 +179,52 @@ describe("degiroConverterV3", () => {
     }, (e) => { console.log(e); done.fail("Should not have an error!"); });
   });
 
+  describe("Spanish keyword classification", () => {
+
+    const record = (description: string, orderId = "") => ({
+      date: "01-01-2024",
+      time: "12:00",
+      currencyDate: "01-01-2024",
+      product: "TEST",
+      isin: "TEST",
+      description,
+      fx: "",
+      currency: "EUR",
+      amount: "1,00",
+      col1: "",
+      col2: "",
+      orderId
+    }) as any;
+
+    const newSut = () =>
+      new DeGiroConverterV3(new SecurityService(new YahooFinanceServiceMock())) as any;
+
+    // Each row: [classifier method name, description, args after the record, expected].
+    // Lowercase + uppercase variants per keyword to lock in lowercase normalization.
+    it.each([
+      // isIgnoredRecord — "fondos del mercado monetario"
+      ["isIgnoredRecord", "Conversión fondos del mercado monetario: Compra 0,002521 @ 9.915,9121 EUR", [], true],
+      ["isIgnoredRecord", "CONVERSIÓN FONDOS DEL MERCADO MONETARIO: Venta 0,001063 @ 9.912,2063 EUR", [], true],
+
+      // isPlatformFees — "comisión de conectividad"
+      ["isPlatformFees", "Comisión de conectividad con el mercado 2024 (New York Stock Exchange - NSY)", [], true],
+      ["isPlatformFees", "COMISIÓN DE CONECTIVIDAD con el mercado 2025 (Xetra - XET)", [], true],
+
+      // isTransactionFeeRecord (buy/sell context) — "y/o"
+      ["isTransactionFeeRecord", "Costes de transacción y/o externos de DEGIRO", [true], true],
+      ["isTransactionFeeRecord", "COSTES DE TRANSACCIÓN Y/O EXTERNOS DE DEGIRO", [true], true],
+
+      // isTransactionFeeRecord (dividend context) — "retención del dividendo"
+      ["isTransactionFeeRecord", "Retención del dividendo", [false], true],
+      ["isTransactionFeeRecord", "RETENCIÓN DEL DIVIDENDO", [false], true],
+    ] as const)("%s(%s) === %s", (method, description, extraArgs, expected) => {
+
+      const sut = newSut();
+      const result = sut[method](record(description), ...extraArgs);
+      expect(result).toBe(expected);
+    });
+  });
+
   it("should log error and invoke errorCallback when an error occurs in processFileContents", (done) => {
    
     // Arrange

--- a/src/converters/degiroConverterV3.test.ts
+++ b/src/converters/degiroConverterV3.test.ts
@@ -200,28 +200,38 @@ describe("degiroConverterV3", () => {
       new DeGiroConverterV3(new SecurityService(new YahooFinanceServiceMock())) as any;
 
     // Each row: [classifier method name, description, args after the record, expected].
-    // Lowercase + uppercase variants per keyword to lock in lowercase normalization.
+    // Lowercase + uppercase variants per keyword lock in lowercase normalization.
     it.each([
-      // isIgnoredRecord — "fondos del mercado monetario"
       ["isIgnoredRecord", "Conversión fondos del mercado monetario: Compra 0,002521 @ 9.915,9121 EUR", [], true],
       ["isIgnoredRecord", "CONVERSIÓN FONDOS DEL MERCADO MONETARIO: Venta 0,001063 @ 9.912,2063 EUR", [], true],
-
-      // isPlatformFees — "comisión de conectividad"
       ["isPlatformFees", "Comisión de conectividad con el mercado 2024 (New York Stock Exchange - NSY)", [], true],
       ["isPlatformFees", "COMISIÓN DE CONECTIVIDAD con el mercado 2025 (Xetra - XET)", [], true],
-
-      // isTransactionFeeRecord (buy/sell context) — "y/o"
       ["isTransactionFeeRecord", "Costes de transacción y/o externos de DEGIRO", [true], true],
       ["isTransactionFeeRecord", "COSTES DE TRANSACCIÓN Y/O EXTERNOS DE DEGIRO", [true], true],
-
-      // isTransactionFeeRecord (dividend context) — "retención del dividendo"
       ["isTransactionFeeRecord", "Retención del dividendo", [false], true],
       ["isTransactionFeeRecord", "RETENCIÓN DEL DIVIDENDO", [false], true],
+
+      // Negative cases: real-trade and unrelated phrases must not be misclassified.
+      ["isIgnoredRecord", "Compra 1 Telefonica SA@3,937 EUR (ES0178430E18)", [], false],
+      ["isIgnoredRecord", "Dividendo", [], false],
+      ["isPlatformFees", "Costes de transacción y/o externos de DEGIRO", [], false],
+      ["isPlatformFees", "compra 1 alphabet inc class a@164,16 usd", [], false],
+      ["isTransactionFeeRecord", "Dividendo", [false], false],
+      ["isTransactionFeeRecord", "Compra 1 Telefonica SA@3,937 EUR", [true], false],
     ] as const)("%s(%s) === %s", (method, description, extraArgs, expected) => {
 
       const sut = newSut();
       const result = sut[method](record(description), ...extraArgs);
       expect(result).toBe(expected);
+    });
+
+    // Dividend-context orderId guard: a real fee phrase still returns false when
+    // paired with a non-empty orderId (V3 line 432 early-return).
+    it("isTransactionFeeRecord returns false for a dividend fee with non-empty orderId", () => {
+
+      const sut = newSut();
+      const result = sut.isTransactionFeeRecord(record("Retención del dividendo", "abc-123"), false);
+      expect(result).toBe(false);
     });
   });
 

--- a/src/converters/degiroConverterV3.ts
+++ b/src/converters/degiroConverterV3.ts
@@ -433,7 +433,7 @@ export class DeGiroConverterV3 extends AbstractConverter {
       return false;
     }
 
-    const transactionFeeRecordType = ["en\/of", "and\/or", "und\/oder", "e\/o", "adr\/gdr", "ritenuta", "belasting", "daň z dividendy", "taxe sur les", "impôts sur", "comissões de transação", "courtage et/ou"];
+    const transactionFeeRecordType = ["en\/of", "and\/or", "und\/oder", "e\/o", "y\/o", "adr\/gdr", "ritenuta", "belasting", "daň z dividendy", "taxe sur les", "impôts sur", "comissões de transação", "courtage et/ou", "retención del dividendo"];
 
     return transactionFeeRecordType.some((t) => record.description.toLocaleLowerCase().indexOf(t) > -1);
   }

--- a/src/converters/degiroConverterV3.ts
+++ b/src/converters/degiroConverterV3.ts
@@ -281,7 +281,8 @@ export class DeGiroConverterV3 extends AbstractConverter {
       "retirada",
       "levantamento de divisa",
       "dito de divisa",
-      "fonds monétaires"];
+      "fonds monétaires",
+      "fondos del mercado monetario"];
 
     return ignoredRecordTypes.some((t) => record.description.toLocaleLowerCase().indexOf(t) > -1);
   }
@@ -439,7 +440,7 @@ export class DeGiroConverterV3 extends AbstractConverter {
 
   private isPlatformFees(record: DeGiroRecord): boolean {
 
-    const platformFeeRecordType = ["aansluitingskosten", "connection fee", "costi di connessione", "verbindungskosten", "custo de conectividade", "frais de connexion", "juros", "corporate action"];
+    const platformFeeRecordType = ["aansluitingskosten", "connection fee", "costi di connessione", "verbindungskosten", "custo de conectividade", "frais de connexion", "comisión de conectividad", "juros", "corporate action"];
 
     return platformFeeRecordType.some((t) => record.description.toLocaleLowerCase().indexOf(t) > -1);
   }


### PR DESCRIPTION
## Added

DEGIRO Spanish-locale recognition keywords across V2 and V3 converters:

- `comisión de conectividad` → `isPlatformFees`. Spanish-language exchange connectivity fees (`Comisión de conectividad con el mercado YYYY (...)`) are now classified as platform fees instead of failing the security lookup.
- `fondos del mercado monetario` → `isIgnoredRecord`. DEGIRO's internal money-market fund cash-sweep pseudo-transactions (`Conversión fondos del mercado monetario: Compra/Venta ... @ ... EUR`) are skipped, matching the existing behaviour for the French `fonds monétaires`.
- `y/o` → `isTransactionFeeRecord`. Spanish trade-fee rows (`Costes de transacción y/o externos de DEGIRO`) now pair with their buy/sell record so the fee ends up on the trade instead of being dropped, matching the existing `en/of`, `and/or`, `und/oder`, `e/o` keywords.
- `retención del dividendo` → `isTransactionFeeRecord`. Spanish dividend-withholding-tax rows (`Retención del dividendo`) now pair with the dividend record as a fee instead of being imported as a duplicate `DIVIDEND` activity (the description contained `dividend` and was matching `isDividendRecord`).
- `rendimiento de capital` → `isDividendRecord` (V2 only). Spanish capital-return rows are recognised as dividends, mirroring the existing English `capital return` keyword. V3 routes non-buy/sell records through `mapDividendRecord` by default, so no change is needed there.

## Fixes

- DEGIRO Spanish account exports failing during processing with `An error occurred trying to retrieve an empty symbol` for market connectivity fee rows.
- DEGIRO Spanish account exports producing invalid Ghostfolio activities (`quantity: 0`, `unitPrice: 0`, `currency: ""`) for money-market fund internal conversion rows, which then failed Ghostfolio import validation with `currency must be a valid ISO4217 currency code`.
- DEGIRO Spanish account exports logging `Record <ISIN> with currency EUR was skipped because it could not be matched to a valid transaction!` for every Spanish trade fee row, with the fee silently dropped from the corresponding buy/sell activity.
- DEGIRO Spanish account exports producing duplicate `DIVIDEND` activities per dividend payment — one for `Dividendo`, one for `Retención del dividendo` — instead of a single dividend with the withholding tax recorded as the fee.
- DEGIRO Spanish account exports silently dropping `Rendimiento de capital` rows.

## Checklist

- [ ] Added relevant changes to README (if applicable) — N/A, multilingual keyword lists are internal.
- [x] Added relevant test(s) — compact `it.each` table per converter in `degiroConverterV2.test.ts` and `degiroConverterV3.test.ts` asserting each new Spanish keyword is recognized by its classifier, with lowercase and uppercase variants to lock in the lowercase-normalization behaviour.
- [ ] Updated the GitVersion file (if not done automatically) — left untouched.

## Related issue (if applicable)

Fixes #..

## Notes

This follows the existing pattern in both converters where the platform-fee, ignored-record, transaction-fee, and dividend-keyword lists already contain entries in Dutch, English, Italian, German, Portuguese, and French. Spanish was the only major DEGIRO-supported locale missing from these lists, and these were the specific terms encountered when running a real Spanish `Account.csv` export end-to-end.

Reproduced and verified locally on a 1398-row Spanish DEGIRO `Account.csv`:

| Stage | Before | After |
|---|---|---|
| Connectivity-fee rows | Crash on first row, full conversion aborted | All rows imported as `FEE` activities |
| Money-market sweep rows | Generated invalid activity (`currency: ""`) that broke Ghostfolio import | Skipped (consistent with `fonds monétaires`) |
| Spanish trade fee rows | Fee dropped, `was skipped because it could not be matched` warning | Fee correctly attached to the corresponding buy/sell |
| Dividend rows with withholding | Two `DIVIDEND` activities per payment (one for the gross, one for the withholding) | Single `DIVIDEND` activity with the withholding as the fee |
| `Rendimiento de capital` rows | Silently dropped | Imported as a `DIVIDEND` activity |

End-to-end the converter now produces a valid Ghostfolio import file with no skip warnings, no empty currencies, and all activities passing ISO4217 validation.