### PR TITLE
fix: Ghostfolio v3 compat, date preservation, rmSync safety

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 0.34.1
+next-version: 0.34.2
 assembly-informational-format: "{NuGetVersion}"
 mode: ContinuousDeployment
 branches:

--- a/src/abstractconverter.test.ts
+++ b/src/abstractconverter.test.ts
@@ -13,6 +13,9 @@ class TestConverter extends AbstractConverter {
     processFileContents(input: string, successCallback: CallableFunction, errorCallback: CallableFunction): void {
         // not needed for header tests
     }
+    exposeProcessHeaders(csvFile: string, splitChar = ","): string[] {
+        return this.processHeaders(csvFile, splitChar);
+    }
 }
 
 describe("AbstractConverter.processHeaders", () => {
@@ -30,7 +33,7 @@ describe("AbstractConverter.processHeaders", () => {
         const csvContent = "Action,Time (UTC),ISIN,Ticker,Name\nBuy,2025-01-01 10:00:00+00:00,US123,AAPL,Apple\n";
 
         // Act
-        const headers = (converter as any).processHeaders(csvContent);
+        const headers = converter.exposeProcessHeaders(csvContent);
 
         // Assert
         expect(headers).toContain("time");
@@ -42,7 +45,7 @@ describe("AbstractConverter.processHeaders", () => {
         const csvContent = "Action,Time,ISIN,Ticker,Name\nBuy,2025-01-01,AAPL,Apple\n";
 
         // Act
-        const headers = (converter as any).processHeaders(csvContent);
+        const headers = converter.exposeProcessHeaders(csvContent);
 
         // Assert
         expect(headers).toContain("time");
@@ -53,7 +56,7 @@ describe("AbstractConverter.processHeaders", () => {
         const csvContent = "Action,iSIN,Ticker\nBuy,US123,AAPL\n";
 
         // Act
-        const headers = (converter as any).processHeaders(csvContent);
+        const headers = converter.exposeProcessHeaders(csvContent);
 
         // Assert
         expect(headers).toContain("isin");
@@ -64,7 +67,7 @@ describe("AbstractConverter.processHeaders", () => {
         const csvContent = "Action,Currency (Total EUR)\nBuy,EUR\n";
 
         // Act
-        const headers = (converter as any).processHeaders(csvContent);
+        const headers = converter.exposeProcessHeaders(csvContent);
 
         // Assert
         expect(headers).toContain("currencyTotalEur");
@@ -75,7 +78,7 @@ describe("AbstractConverter.processHeaders", () => {
         const csvContent = "Action,Time (UTC),ISIN,Ticker,Name,Notes,ID,No. of shares,Price / share,Currency (Price / share),Exchange rate,Total,Currency (Total),Withholding tax,Currency (Withholding tax),Currency conversion fee,Currency (Currency conversion fee)\n";
 
         // Act
-        const headers = (converter as any).processHeaders(csvContent);
+        const headers = converter.exposeProcessHeaders(csvContent);
 
         // Assert - key headers should be mapped correctly
         expect(headers).toContain("action");

--- a/src/abstractconverter.test.ts
+++ b/src/abstractconverter.test.ts
@@ -1,0 +1,90 @@
+import { AbstractConverter } from "./converters/abstractconverter";
+import { SecurityService } from "./securityService";
+import YahooFinanceServiceMock from "./testing/yahooFinanceServiceMock";
+
+// Concrete subclass for testing
+class TestConverter extends AbstractConverter {
+    constructor(securityService: SecurityService) {
+        super(securityService);
+    }
+    isIgnoredRecord(record: any): boolean {
+        return false;
+    }
+    processFileContents(input: string, successCallback: CallableFunction, errorCallback: CallableFunction): void {
+        // not needed for header tests
+    }
+}
+
+describe("AbstractConverter.processHeaders", () => {
+
+    let converter: TestConverter;
+
+    beforeAll(() => {
+        const mockYahoo = new YahooFinanceServiceMock();
+        const securityService = new SecurityService(mockYahoo);
+        converter = new TestConverter(securityService);
+    });
+
+    it("should map 'Time (UTC)' to 'time'", () => {
+        // Arrange
+        const csvContent = "Action,Time (UTC),ISIN,Ticker,Name\nBuy,2025-01-01 10:00:00+00:00,US123,AAPL,Apple\n";
+
+        // Act
+        const headers = (converter as any).processHeaders(csvContent);
+
+        // Assert
+        expect(headers).toContain("time");
+        expect(headers).not.toContain("timeUTC");
+    });
+
+    it("should map 'Time' to 'time' (backward compatible)", () => {
+        // Arrange
+        const csvContent = "Action,Time,ISIN,Ticker,Name\nBuy,2025-01-01,AAPL,Apple\n";
+
+        // Act
+        const headers = (converter as any).processHeaders(csvContent);
+
+        // Assert
+        expect(headers).toContain("time");
+    });
+
+    it("should map 'iSIN' to 'isin'", () => {
+        // Arrange
+        const csvContent = "Action,iSIN,Ticker\nBuy,US123,AAPL\n";
+
+        // Act
+        const headers = (converter as any).processHeaders(csvContent);
+
+        // Assert
+        expect(headers).toContain("isin");
+    });
+
+    it("should map headers ending with 'EUR' to camelCase with 'Eur'", () => {
+        // Arrange
+        const csvContent = "Action,Currency (Total EUR)\nBuy,EUR\n";
+
+        // Act
+        const headers = (converter as any).processHeaders(csvContent);
+
+        // Assert
+        expect(headers).toContain("currencyTotalEur");
+    });
+
+    it("should handle all Trading212 headers correctly", () => {
+        // Arrange - full Trading212 header
+        const csvContent = "Action,Time (UTC),ISIN,Ticker,Name,Notes,ID,No. of shares,Price / share,Currency (Price / share),Exchange rate,Total,Currency (Total),Withholding tax,Currency (Withholding tax),Currency conversion fee,Currency (Currency conversion fee)\n";
+
+        // Act
+        const headers = (converter as any).processHeaders(csvContent);
+
+        // Assert - key headers should be mapped correctly
+        expect(headers).toContain("action");
+        expect(headers).toContain("time");
+        expect(headers).toContain("isin");
+        expect(headers).toContain("ticker");
+        expect(headers).toContain("name");
+        expect(headers).toContain("noOfShares");
+        expect(headers).toContain("priceShare");
+        expect(headers).toContain("currencyPriceShare");
+    });
+});

--- a/src/converters/abstractconverter.ts
+++ b/src/converters/abstractconverter.ts
@@ -84,6 +84,8 @@ export abstract class AbstractConverter {
             // Manual polishing..
             if (col === "iSIN") {
                 col = col.toLocaleLowerCase();
+            } else if (col === "timeUTC") {
+                col = "time";
             } else if (col.endsWith("EUR")) {
                 col = col.slice(0, -3) + "Eur";
             } else if (col.endsWith("CHF")) {

--- a/src/ghostfolioService.test.ts
+++ b/src/ghostfolioService.test.ts
@@ -1,0 +1,139 @@
+import GhostfolioService from "./ghostfolioService";
+import * as fs from "fs";
+
+// Mock fetch globally
+const mockFetch = jest.fn();
+global.fetch = mockFetch as any;
+
+describe("GhostfolioService", () => {
+
+    beforeAll(() => {
+        process.env.GHOSTFOLIO_URL = "http://localhost:3333";
+        process.env.GHOSTFOLIO_SECRET = "test-secret";
+        process.env.GHOSTFOLIO_VALIDATE = "true";
+        process.env.GHOSTFOLIO_IMPORT = "true";
+    });
+
+    beforeEach(() => {
+        mockFetch.mockReset();
+    });
+
+    describe("authenticate", () => {
+
+        it("should use POST with accessToken body for Ghostfolio v3+", async () => {
+            // Arrange
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ authToken: "test-token-123" })
+            });
+
+            const service = new GhostfolioService();
+
+            // Act - trigger authenticate via validate (which calls authenticate on 401)
+            // First call: validate gets 401, triggers authenticate
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 201,
+                json: async () => ({})
+            });
+
+            // We need to call validate to trigger authenticate
+            // But validate reads a file, so let's test authenticate indirectly
+            // by checking the fetch call format
+
+            // Access private method via any cast
+            await (service as any).authenticate(true);
+
+            // Assert
+            expect(mockFetch).toHaveBeenCalledWith(
+                "http://localhost:3333/api/v1/auth/anonymous",
+                expect.objectContaining({
+                    method: "POST",
+                    headers: expect.arrayContaining([
+                        ["Content-Type", "application/json"]
+                    ]),
+                    body: JSON.stringify({ accessToken: "test-secret" })
+                })
+            );
+        });
+
+        it("should throw on non-ok response", async () => {
+            // Arrange
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+                statusText: "Not Found"
+            });
+
+            const service = new GhostfolioService();
+
+            // Act & Assert
+            await expect((service as any).authenticate(true))
+                .rejects.toThrow("Authentication failed: 404 Not Found");
+        });
+
+        it("should throw when authToken is missing from response", async () => {
+            // Arrange
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({})  // no authToken
+            });
+
+            const service = new GhostfolioService();
+
+            // Act & Assert
+            await expect((service as any).authenticate(true))
+                .rejects.toThrow("Authentication succeeded but no authToken was returned");
+        });
+
+        it("should cache token and not re-authenticate on subsequent calls", async () => {
+            // Arrange
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ authToken: "cached-token" })
+            });
+
+            const service = new GhostfolioService();
+
+            // Act - first call authenticates
+            await (service as any).authenticate(true);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+
+            // Act - second call with refresh=false should skip
+            await (service as any).authenticate(false);
+            expect(mockFetch).toHaveBeenCalledTimes(1); // still 1
+        });
+    });
+
+    describe("retryCount", () => {
+
+        it("should stop after 3 retries (retryCount advances correctly)", async () => {
+            // Arrange
+            const service = new GhostfolioService();
+            const tmpFile = "/tmp/test-validate.json";
+            fs.writeFileSync(tmpFile, JSON.stringify({ activities: [] }));
+
+            // Mock fetch: auth always succeeds, validate always returns 401
+            mockFetch.mockImplementation(async (url: string) => {
+                if (url.includes("/auth/anonymous")) {
+                    return { ok: true, json: async () => ({ authToken: "token" }) };
+                }
+                // validate endpoint - always 401 to trigger retry
+                return { ok: true, status: 401, json: async () => ({}) };
+            });
+
+            // Act & Assert - should throw after 3 retries (retryCount 0→1→2→3)
+            await expect(service.validate(tmpFile, 0))
+                .rejects.toThrow("Failed to validate export file because of authentication error");
+
+            // Auth should have been called 3 times (retryCount 0→1→2, then 3 throws before auth)
+            const authCalls = mockFetch.mock.calls.filter(
+                (call: any) => call[0].includes("/auth/anonymous")
+            );
+            expect(authCalls.length).toBe(3);
+
+            // Cleanup
+            fs.unlinkSync(tmpFile);
+        });
+    });
+});

--- a/src/ghostfolioService.test.ts
+++ b/src/ghostfolioService.test.ts
@@ -5,6 +5,12 @@ import * as fs from "fs";
 const mockFetch = jest.fn();
 global.fetch = mockFetch as any;
 
+jest.mock("fs", () => ({
+    ...jest.requireActual("fs"),
+    readFileSync: jest.fn()
+}));
+const mockedFs = jest.mocked(fs);
+
 describe("GhostfolioService", () => {
 
     beforeAll(() => {
@@ -29,19 +35,7 @@ describe("GhostfolioService", () => {
 
             const service = new GhostfolioService();
 
-            // Act - trigger authenticate via validate (which calls authenticate on 401)
-            // First call: validate gets 401, triggers authenticate
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                status: 201,
-                json: async () => ({})
-            });
-
-            // We need to call validate to trigger authenticate
-            // But validate reads a file, so let's test authenticate indirectly
-            // by checking the fetch call format
-
-            // Access private method via any cast
+            // Act
             await (service as any).authenticate(true);
 
             // Assert
@@ -110,8 +104,7 @@ describe("GhostfolioService", () => {
         it("should stop after 3 retries (retryCount advances correctly)", async () => {
             // Arrange
             const service = new GhostfolioService();
-            const tmpFile = "/tmp/test-validate.json";
-            fs.writeFileSync(tmpFile, JSON.stringify({ activities: [] }));
+            mockedFs.readFileSync.mockReturnValue(JSON.stringify({ activities: [] }));
 
             // Mock fetch: auth always succeeds, validate always returns 401
             mockFetch.mockImplementation(async (url: string) => {
@@ -123,7 +116,7 @@ describe("GhostfolioService", () => {
             });
 
             // Act & Assert - should throw after 3 retries (retryCount 0→1→2→3)
-            await expect(service.validate(tmpFile, 0))
+            await expect(service.validate("/fake/path.json", 0))
                 .rejects.toThrow("Failed to validate export file because of authentication error");
 
             // Auth should have been called 3 times (retryCount 0→1→2, then 3 throws before auth)
@@ -131,9 +124,6 @@ describe("GhostfolioService", () => {
                 (call: any) => call[0].includes("/auth/anonymous")
             );
             expect(authCalls.length).toBe(3);
-
-            // Cleanup
-            fs.unlinkSync(tmpFile);
         });
     });
 });

--- a/src/ghostfolioService.ts
+++ b/src/ghostfolioService.ts
@@ -134,8 +134,12 @@ export default class GhostfolioService {
         // Only get bearer when it isn't set or has to be refreshed.
         if (!this.cachedBearerToken || refresh) {
 
-            // Retrieve bearer token for authentication.
-            const bearerResponse = await fetch(`${process.env.GHOSTFOLIO_URL}/api/v1/auth/anonymous/${process.env.GHOSTFOLIO_SECRET}`);
+            // Retrieve bearer token for authentication (POST with accessToken body — Ghostfolio v3+).
+            const bearerResponse = await fetch(`${process.env.GHOSTFOLIO_URL}/api/v1/auth/anonymous`, {
+                method: "POST",
+                headers: [["Content-Type", "application/json"]],
+                body: JSON.stringify({ accessToken: process.env.GHOSTFOLIO_SECRET })
+            });
             const bearer = await bearerResponse.json();
             this.cachedBearerToken = bearer.authToken;
             return;

--- a/src/ghostfolioService.ts
+++ b/src/ghostfolioService.ts
@@ -140,7 +140,17 @@ export default class GhostfolioService {
                 headers: [["Content-Type", "application/json"]],
                 body: JSON.stringify({ accessToken: process.env.GHOSTFOLIO_SECRET })
             });
+
+            if (!bearerResponse.ok) {
+                throw new Error(`Authentication failed: ${bearerResponse.status} ${bearerResponse.statusText}`);
+            }
+
             const bearer = await bearerResponse.json();
+
+            if (!bearer.authToken) {
+                throw new Error("Authentication succeeded but no authToken was returned");
+            }
+
             this.cachedBearerToken = bearer.authToken;
             return;
         }

--- a/src/ghostfolioService.ts
+++ b/src/ghostfolioService.ts
@@ -52,7 +52,7 @@ export default class GhostfolioService {
         if (validationResult.status === 401) {
 
             await this.authenticate(true);
-            return await this.validate(path, retryCount++);
+            return await this.validate(path, retryCount + 1);
         }
 
         // If status is 400, then import failed. 
@@ -107,7 +107,7 @@ export default class GhostfolioService {
         if (importResult.status === 401) {
 
             await this.authenticate(true);
-            return await this.import(path, retryCount++);
+            return await this.import(path, retryCount + 1);
         }
 
         var response = await importResult.json();

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -65,7 +65,7 @@ chokidar
 
                 // After conversion was succesful, remove input file.
                 console.log(`[i] Finished converting ${path.basename(filePath)}, removing file..`);
-                fs.rmSync(filePath);
+                fs.rmSync(filePath, { force: true });
 
                 isProcessing = false;
 
@@ -83,7 +83,7 @@ chokidar
                 console.log("[e] Moving file to output..");
                 const errorFilePath = path.join(outputFolder, path.basename(filePath));
                 fs.copyFileSync(filePath, errorFilePath);
-                fs.rmSync(filePath);
+                fs.rmSync(filePath, { force: true });
 
                 isProcessing = false;
 


### PR DESCRIPTION
Fixes three bugs that break the converter with Ghostfolio v3.30.0+ and Trading212 CSV exports.
## Problem
1. **Auth endpoint changed** — Ghostfolio v3.30.0 moved anonymous auth from `GET /api/v1/auth/anonymous/{secret}` to `POST /api/v1/auth/anonymous` with `{ accessToken }` body. The old GET format returns 404, which triggers infinite retry loops that exhaust the 4GB heap (OOM crash).
2. **All activity dates wrong** — `processHeaders()` camelizes `Time (UTC)` to `timeUTC`, but the converter accesses `record.time`. Since `record.time` is undefined, `dayjs(undefined)` falls back to today's date for every activity. This means buy/sell/dividend dates are all lost.
3. **rmSync crash on cleanup** — `fs.rmSync(filePath)` throws ENOENT when the orchestrator script has already removed the input file before the container finishes processing.
4. **Infinite retry on auth failure** — `retryCount++` (postfix) passes the original value to recursive calls, so the `retryCount === 3` termination is never reached.
5. **Silent auth failures** — `authenticate()` doesn't check `response.ok` before parsing JSON, so a failed auth (wrong secret, network error) silently sets `cachedBearerToken` to undefined.
## Changes
| File | Fix |
|------|-----|
| `src/ghostfolioService.ts` | POST auth with JSON body + response.ok check + fix retryCount to `retryCount + 1` |
| `src/converters/abstractconverter.ts` | Map `timeUTC` header to `time` in `processHeaders()` |
| `src/watcher.ts` | `{ force: true }` on both `rmSync` calls |
## Testing
Verified against a Trading212 CSV with 970 rows (buys, sells, dividends, interest):
- All dates preserved correctly (previously all showed today's date)
- Validation passes, import succeeds (950 activities imported)
- No OOM, no rmSync crashes, no infinite retries

## Added

- 
 
## Fixes

-

## Checklist

- [ ] Added relevant changes to README (if applicable)
- [x] Added relevant test(s)
- [x] Updated the GitVersion file (if not done automatically)

## Related issue (if applicable)

Fixes #..
